### PR TITLE
Assign maintainers as reviewers for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "06:00"
+    reviewers:
+      - "prelude-music/maintainers"


### PR DESCRIPTION
As per https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#reviewers