### PR TITLE
Use native Node.js source maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "json5": "^2.2.3",
         "mime": "^4.0.4",
         "music-metadata": "^10.0.0",
-        "source-map-support": "^0.5.21",
         "yaml": "^2.4.5"
       },
       "devDependencies": {
@@ -120,12 +119,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
     },
     "node_modules/chownr": {
       "version": "1.1.4",
@@ -559,25 +552,6 @@
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/string_decoder": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "start": "node ./dist/index.js",
+    "start": "node --enable-source-maps ./dist/index.js",
     "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "json5": "^2.2.3",
     "mime": "^4.0.4",
     "music-metadata": "^10.0.0",
-    "source-map-support": "^0.5.21",
     "yaml": "^2.4.5"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import 'source-map-support/register.js'
 import Server from "./Server.js";
 import Config from "./Config.js";
 import Library from "./Library.js";


### PR DESCRIPTION
Removes the source map dependency and instead uses `--enable-source-maps` together with our inline TS source maps.