### PR TITLE
Users, Tokens, Authentication and Authorisation

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,8 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <codeStyleSettings language="yaml">
+      <option name="SPACE_WITHIN_BRACKETS" value="false" />
+      <option name="SPACE_WITHIN_BRACES" value="false" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -42,7 +42,41 @@ tags: [
       The track ID is a hash of the artist's name, the album's name (or whether present), and the track name itself.
       Changing any of these will result in a new ID. Track IDs will be identical across Prelude server instances of the
       same version."
+  },
+  {
+    name: Users,
+    description: "Users are accounts secured by a password that can be used to access the Prelude server."
+  },
+  {
+    name: Tokens,
+    description: "Tokens enable authentication with the Prelude server. Using the token scopes,
+      you can control what endpoints the API token can be used for.
+      
+      
+      The available token scopes are:
+      
+      | Scope             | Description                                                                                              | Recommended For |
+      
+      |-------------------|----------------------------------------------------------------------------------------------------------|-----------------|
+      
+      | `library:read`    | Read-only access to Artists, Albums, and Tracks.                                                        | everyone        |
+      
+      | `library:write`   | Write/modify access to Artists, Albums, and Tracks. Allows the user to upload/delete audio files.        | admin           |
+      
+      | `tokens:read:self`| Read-only access to your Tokens.                                                                        | everyone        |
+      
+      | `tokens:write:self`| Write/modify access to your Tokens.                                                                      | everyone        |
+      
+      | `tokens:read:all` | Read-only access to everyone's Tokens.                                                                  | admin           |
+      
+      | `tokens:write:all`| Write/modify access to everyone's Tokens.                                                                | admin           |
+      
+      | `users:read`      | Read-only access to Users.                                                                              | admin           |
+      
+      | `users:write`     | Write/modify access to Users.                                                                           | admin           |
+      "
   }
+
 ]
 
 paths:
@@ -682,16 +716,528 @@ paths:
         403:
           $ref: "#/components/responses/Forbidden"
 
+  /users:
+    get:
+      tags: [ Users ]
+      summary: List Users
+      security:
+        - basic: [ users:read ]
+        - bearer: [ users:read ]
+      parameters: [
+        {
+          in: query,
+          description: Number of resources to return per page,
+          name: limit,
+          schema: {
+            type: integer,
+            default: 100,
+            minimum: 1
+          }
+        },
+        {
+          in: query,
+          description: Page number to return,
+          name: page,
+          schema: {
+            type: integer,
+            default: 1,
+            minimum: 1
+          }
+        }
+      ]
+      responses:
+        200:
+          description: A page of users
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Page<T>"
+                  - type: object
+                    properties:
+                      resources:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/User"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags: [ Users ]
+      summary: Create User
+      security:
+        - basic: [ users:write ]
+        - bearer: [ users:write ]
+      requestBody:
+        $ref: "#/components/requestBodies/User"
+      responses:
+        200:
+          description: The created user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    delete:
+      tags: [ Users ]
+      summary: Delete All Users
+      description: Will delete all users and all tokens.
+      security:
+        - basic: [ users:write ]
+        - bearer: [ users:write ]
+      responses:
+        204:
+          description: All users deleted successfully
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+
+  /users/{id}:
+    get:
+      tags: [ Users ]
+      summary: Get User
+      security:
+        - basic: [ users:read ]
+        - bearer: [ users:read ]
+      parameters: [
+        {
+          in: path,
+          name: id,
+          required: true,
+          schema: { $ref: "#/components/schemas/User/properties/id" }
+        }
+      ]
+      responses:
+        200:
+          description: The requested user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        404:
+          description: The requested user could not be found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    delete:
+      tags: [ Users ]
+      summary: Delete User
+      security:
+        - basic: [ users:write ]
+        - bearer: [ users:write ]
+      parameters: [
+        {
+          in: path,
+          name: id,
+          required: true,
+          schema: { $ref: "#/components/schemas/User/properties/id" }
+        }
+      ]
+      responses:
+        204:
+          description: The requested user was deleted successfully
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    put:
+      tags: [ Users ]
+      summary: Update User
+      security:
+        - basic: [ users:write ]
+        - bearer: [ users:write ]
+      parameters: [
+        {
+          in: path,
+          name: id,
+          required: true,
+          schema: { $ref: "#/components/schemas/User/properties/id" }
+        }
+      ]
+      requestBody:
+        $ref: "#/components/requestBodies/User"
+      responses:
+        200:
+          description: The updated user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        404:
+          description: The requested user could not be found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    patch:
+      tags: [ Users ]
+      summary: Partially Update User
+      security:
+        - basic: [ users:write ]
+        - bearer: [ users:write ]
+      parameters: [
+        {
+          in: path,
+          name: id,
+          required: true,
+          schema: { $ref: "#/components/schemas/User/properties/id" }
+        }
+      ]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserWrite"
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/UserWrite"
+      responses:
+        200:
+          description: The updated user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+
+  /tokens:
+    get:
+      tags: [ Tokens ]
+      summary: List Tokens
+      security:
+        - basic: [ tokens:read:self ]
+        - bearer: [ tokens:read:self ]
+        - basic: [ tokens:read:all ]
+        - bearer: [ tokens:read:all ]
+      parameters: [
+        {
+          in: query,
+          description: Number of resources to return per page,
+          name: limit,
+          schema: {
+            type: integer,
+            default: 100,
+            minimum: 1
+          }
+        },
+        {
+          in: query,
+          description: Page number to return,
+          name: page,
+          schema: {
+            type: integer,
+            default: 1,
+            minimum: 1
+          }
+        },
+        {
+          in: query,
+          description: Get tokens for a specific user. Incompatible with the `note` parameter.,
+          name: user,
+          schema: {
+            $ref: "#/components/schemas/User/properties/id"
+          }
+        },
+        {
+          in: query,
+          description: "Get ALL tokens. By default, only the tokens of the authenticated user are returned.
+            Incompatible with the `user` parameter.",
+          name: all
+        }
+      ]
+      responses:
+        200:
+          description: A page of tokens
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Page<T>"
+                  - type: object
+                    properties:
+                      resources:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Token"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags: [ Tokens ]
+      summary: Create Token
+      security:
+        - basic: [ tokens:write:self ]
+        - bearer: [ tokens:write:self ]
+        - basic: [ tokens:write:all ]
+        - bearer: [ tokens:write:all ]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [ user, expires, scopes, note ]
+              properties:
+                user:
+                  description: The ID of the user to create this token for. You can only use this if you have the `tokens:write:all` scope.
+                  allOf:
+                    - $ref: "#/components/schemas/User/properties/id"
+                expires:
+                  $ref: "#/components/schemas/Token/properties/expires"
+                scopes:
+                  $ref: "#/components/schemas/Token/properties/scopes"
+                note:
+                  $ref: "#/components/schemas/Token/properties/note"
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [ user, expires, scopes, note ]
+              properties:
+                user:
+                  description: The ID of the user to create this token for. You can only use this if you have the `tokens:write:all` scope.
+                  allOf:
+                    - $ref: "#/components/schemas/User/properties/id"
+                expires:
+                  $ref: "#/components/schemas/Token/properties/expires"
+                scopes:
+                  $ref: "#/components/schemas/Token/properties/scopes"
+                note:
+                  $ref: "#/components/schemas/Token/properties/note"
+      responses:
+        201:
+          description: The created token
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Token"
+                  - type: object
+                    properties:
+                      secret:
+                        type: string
+                        description: The token secret key used for authenticating requests. This is never available again.
+                        example: ED80gmnuZumZ5N2kA0exhN2FVjpdBdk2jVze
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    delete:
+      tags: [ Tokens ]
+      summary: Delete All Tokens
+      security:
+        - basic: [ tokens:write:self ]
+        - bearer: [ tokens:write:self ]
+        - basic: [ tokens:write:all ]
+        - bearer: [ tokens:write:all ]
+      responses:
+        204:
+          description: All tokens deleted successfully
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+
+  /tokens/{id}:
+    get:
+      tags: [ Tokens ]
+      summary: Get Token
+      security:
+        - basic: [ tokens:read:self ]
+        - bearer: [ tokens:read:self ]
+        - basic: [ tokens:read:all ]
+        - bearer: [ tokens:read:all ]
+      parameters: [
+        {
+          in: path,
+          name: id,
+          required: true,
+          schema: { $ref: "#/components/schemas/Token/properties/id" }
+        }
+      ]
+      responses:
+        200:
+          description: The token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Token"
+        404:
+          description: The requested token could not be found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    delete:
+      tags: [ Tokens ]
+      summary: Delete Token
+      security:
+        - basic: [ tokens:write:self ]
+        - bearer: [ tokens:write:self ]
+        - basic: [ tokens:write:all ]
+        - bearer: [ tokens:write:all ]
+      parameters: [
+        {
+          in: path,
+          name: id,
+          required: true,
+          schema: { $ref: "#/components/schemas/Token/properties/id" }
+        }
+      ]
+      responses:
+        204:
+          description: The requested token was deleted successfully
+        404:
+          description: The requested token could not be found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    put:
+      tags: [ Tokens ]
+      summary: Update Token
+      security:
+        - basic: [ tokens:write:self ]
+        - bearer: [ tokens:write:self ]
+        - basic: [ tokens:write:all ]
+        - bearer: [ tokens:write:all ]
+      parameters: [
+        {
+          in: path,
+          name: id,
+          required: true,
+          schema: { $ref: "#/components/schemas/Token/properties/id" }
+        }
+      ]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [ note ]
+              properties:
+                note:
+                  $ref: "#/components/schemas/Token/properties/note"
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required: [ note ]
+              properties:
+                note:
+                  $ref: "#/components/schemas/Token/properties/note"
+      responses:
+        200:
+          description: The updated token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Token"
+        404:
+          description: The requested token could not be found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    patch:
+      tags: [ Tokens ]
+      summary: Partially Update Token
+      security:
+        - basic: [ tokens:write:self ]
+        - bearer: [ tokens:write:self ]
+        - basic: [ tokens:write:all ]
+        - bearer: [ tokens:write:all ]
+      parameters: [
+        {
+          in: path,
+          name: id,
+          required: true,
+          schema: { $ref: "#/components/schemas/Token/properties/id" }
+        }
+      ]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                note:
+                  $ref: "#/components/schemas/Token/properties/note"
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                note:
+                  $ref: "#/components/schemas/Token/properties/note"
+      responses:
+        200:
+          description: The updated token
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Token"
+        404:
+          description: The requested token could not be found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+
 components:
   securitySchemes:
     basic:
       type: http
       scheme: Basic
-      description: Authenticate using username and password. All scopes granted on your user account will apply.
+      description: Authenticate using username and password. All scopes granted on your user account will apply. Please use HTTPS.
     bearer:
       type: http
       scheme: Bearer
       description: Authenticate using an API Token.
+  responses:
+    Unauthorised:
+      description: |-
+        Authorisation is missing or invalid. Possible causes for authorisation to be invalid are
+          - the username or password is incorrect
+          - the token secret is incorrect
+          - the token secret is correct, but the token has expired
+          - the username and password, or the token secret, are/is correct, but the user is disabled
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    Forbidden:
+      description: The scopes of the user or token used to authenticate this request lacked the required scope for this endpoint.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
   schemas:
     Artist:
       type: object
@@ -810,6 +1356,59 @@ components:
               description: Whether the audio file is in a lossless/uncompressed format
               example: false
 
+    User:
+      type: object
+      properties:
+        id:
+          type: string
+          title: User ID
+          example: d7e33c2c-0454-4da5-b079-d46e7b47cf22
+        username:
+          type: string
+          title: Unique username. Used for Basic auth with username and password
+          example: user123
+          minLength: 3
+          maxLength: 24
+          pattern: ^[a-zA-Z0-9-._]+$
+        scopes:
+          type: array
+          items:
+            $ref: "#/components/schemas/Scope"
+          title: User scopes
+        disabled:
+          type: boolean
+          title: If true, the user cannot authenticate any API requests (even with tokens).
+          example: false
+
+    Token:
+      type: object
+      properties:
+        id:
+          type: string
+          title: Token ID
+          example: 7e10e4ff-be3f-46d0-9865-941c3d6b62c8
+        user:
+          $ref: "#/components/schemas/User/properties/id"
+        expires:
+          description: The date in Unix time when the token expires. If null, the token does not expire. After the token expires, the server will consider it invalid.
+          type: integer
+          format: unix-time
+          nullable: true
+          example: 1893448800
+        scopes:
+          type: array
+          items:
+            $ref: "#/components/schemas/Scope"
+          title: Token scopes
+        note:
+          type: string
+          description: A user-specified note for the token (e.g. description of what this token is for).
+
+    Scope:
+      description: Controls access to API resources
+      type: string
+      enum: [ library:read, library:write, tokens:read:self, tokens:write:self, tokens:read:all, tokens:write:all, users:read, users:write ]
+
     Page<T>:
       description: A page is a partial list of items from a larger collection
       type: object
@@ -851,3 +1450,47 @@ components:
             message:
               type: string
               example: A user-friendly error message.
+            fields:
+              type: object
+              additionalProperties:
+                type: string
+                example: Field-specific errors mapped to request body fields. If this object is not empty, these error messages should be shown instead of the one in `message`.
+
+    BooleanLike:
+      oneOf:
+        - type: boolean
+          enum: [ true, false ]
+        - type: string
+          enum: [ "true", "false", "1", "0", "on" ]
+        - type: integer
+          enum: [ 1, 0 ]
+      example: false
+
+    UserWrite:
+      type: object
+      properties:
+        username:
+          $ref: "#/components/schemas/User/properties/username"
+        password:
+          type: string
+          description: Plain-text password. Please use HTTPS.
+          example: "VerySecure123!"
+        scopes:
+          $ref: "#/components/schemas/User/properties/scopes"
+        disabled:
+          $ref: "#/components/schemas/BooleanLike"
+
+  requestBodies:
+    User:
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/UserWrite"
+            required: [ username, password, scopes, disabled ]
+        application/x-www-form-urlencoded:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/UserWrite"
+            required: [ username, password, scopes, disabled ]
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -105,6 +105,9 @@ paths:
     get:
       tags: [ Artists ]
       summary: List Artists
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: query,
@@ -155,6 +158,9 @@ paths:
     get:
       tags: [ Artists ]
       summary: Get Artist
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: path,
@@ -181,6 +187,9 @@ paths:
     get:
       tags: [ Artists ]
       summary: List Albums of Artist
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: path,
@@ -228,6 +237,9 @@ paths:
     get:
       tags: [ Artists ]
       summary: List Tracks of Artist
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: path,
@@ -275,6 +287,9 @@ paths:
     get:
       tags: [ Artists ]
       summary: Get Image of Artist
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: path,
@@ -305,6 +320,9 @@ paths:
     get:
       tags: [ Albums ]
       summary: List Albums
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: query,
@@ -346,6 +364,9 @@ paths:
     get:
       tags: [ Albums ]
       summary: Get Album
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: path,
@@ -373,6 +394,9 @@ paths:
       tags: [ Albums ]
       summary: List Tracks in Album
       description: The tracks are always sorted by `Track#track.no` (if available).
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: path,
@@ -421,6 +445,9 @@ paths:
       tags: [ Albums ]
       summary: Get Image of Album
       description: The image is obtained from the metadata of one of the first 5 tracks in the album.
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: path,
@@ -445,6 +472,9 @@ paths:
     get:
       tags: [ Tracks ]
       summary: List Tracks
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: query,
@@ -505,6 +535,9 @@ paths:
     get:
       tags: [ Tracks ]
       summary: Get Track
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: path,
@@ -531,6 +564,9 @@ paths:
     get:
       tags: [ Tracks ]
       summary: Get Audio of Track
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: path,
@@ -571,6 +607,9 @@ paths:
       tags: [ Tracks ]
       summary: Get Image of Track
       description: Obtained from the track metadata
+      security:
+        - basic: []
+        - bearer: [library:read]
       parameters: [
         {
           in: path,
@@ -592,6 +631,15 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
 
 components:
+  securitySchemes:
+    basic:
+      type: http
+      scheme: Basic
+      description: Authenticate using username and password. All scopes granted on your user account will apply.
+    bearer:
+      type: http
+      scheme: Bearer
+      description: Authenticate using an API Token.
   schemas:
     Artist:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -106,7 +106,7 @@ paths:
       tags: [ Artists ]
       summary: List Artists
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {
@@ -159,7 +159,7 @@ paths:
       tags: [ Artists ]
       summary: Get Artist
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {
@@ -188,7 +188,7 @@ paths:
       tags: [ Artists ]
       summary: List Albums of Artist
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {
@@ -238,7 +238,7 @@ paths:
       tags: [ Artists ]
       summary: List Tracks of Artist
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {
@@ -288,7 +288,7 @@ paths:
       tags: [ Artists ]
       summary: Get Image of Artist
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {
@@ -321,7 +321,7 @@ paths:
       tags: [ Albums ]
       summary: List Albums
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {
@@ -365,7 +365,7 @@ paths:
       tags: [ Albums ]
       summary: Get Album
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {
@@ -395,7 +395,7 @@ paths:
       summary: List Tracks in Album
       description: The tracks are always sorted by `Track#track.no` (if available).
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {
@@ -446,7 +446,7 @@ paths:
       summary: Get Image of Album
       description: The image is obtained from the metadata of one of the first 5 tracks in the album.
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {
@@ -473,7 +473,7 @@ paths:
       tags: [ Tracks ]
       summary: List Tracks
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {
@@ -536,7 +536,7 @@ paths:
       tags: [ Tracks ]
       summary: Get Track
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {
@@ -565,7 +565,7 @@ paths:
       tags: [ Tracks ]
       summary: Get Audio of Track
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {
@@ -608,7 +608,7 @@ paths:
       summary: Get Image of Track
       description: Obtained from the track metadata
       security:
-        - basic: []
+        - basic: [library:read]
         - bearer: [library:read]
       parameters: [
         {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -82,7 +82,7 @@ tags: [
 paths:
   /:
     get:
-      tags: [ Prelude ]
+      tags: [Prelude]
       summary: API Server Info
       description: Basic information about the running Prelude server instance.
       responses:
@@ -115,29 +115,29 @@ paths:
 
   /openapi.yaml:
     get:
-      tags: [ Prelude ]
+      tags: [Prelude]
       summary: OpenAPI YAML Specification
       description: The OpenAPI specification from the server repository
       responses:
         200:
           description: The raw file
           content:
-            text/yaml: { }
+            text/yaml: {}
 
   /openapi.json:
     get:
-      tags: [ Prelude ]
+      tags: [Prelude]
       summary: OpenAPI JSON Specification
       description: A JSON version of the OpenAPI specification. This is a literal JSON representation of YAML version.
       responses:
         200:
           description: A parsed representation from the YAML version, serialised into JSON
           content:
-            application/json: { }
+            application/json: {}
 
   /artists:
     get:
-      tags: [ Artists ]
+      tags: [Artists]
       summary: List Artists
       security:
         - basic: [library:read]
@@ -169,7 +169,7 @@ paths:
           name: id,
           schema: {
             type: array,
-            items: { type: string }
+            items: {type: string}
           }
         }
       ]
@@ -194,7 +194,7 @@ paths:
 
   /artists/{id}:
     get:
-      tags: [ Artists ]
+      tags: [Artists]
       summary: Get Artist
       security:
         - basic: [library:read]
@@ -204,7 +204,7 @@ paths:
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Artist/properties/id" }
+          schema: {$ref: "#/components/schemas/Artist/properties/id"}
         }
       ]
       responses:
@@ -227,7 +227,7 @@ paths:
 
   /artists/{id}/albums:
     get:
-      tags: [ Artists ]
+      tags: [Artists]
       summary: List Albums of Artist
       security:
         - basic: [library:read]
@@ -237,7 +237,7 @@ paths:
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Artist/properties/id" }
+          schema: {$ref: "#/components/schemas/Artist/properties/id"}
         },
         {
           in: query,
@@ -281,7 +281,7 @@ paths:
 
   /artists/{id}/tracks:
     get:
-      tags: [ Artists ]
+      tags: [Artists]
       summary: List Tracks of Artist
       security:
         - basic: [library:read]
@@ -291,7 +291,7 @@ paths:
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Artist/properties/id" }
+          schema: {$ref: "#/components/schemas/Artist/properties/id"}
         },
         {
           in: query,
@@ -335,7 +335,7 @@ paths:
 
   /artists/{id}/image:
     get:
-      tags: [ Artists ]
+      tags: [Artists]
       summary: Get Image of Artist
       security:
         - basic: [library:read]
@@ -345,14 +345,14 @@ paths:
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Artist/properties/id" }
+          schema: {$ref: "#/components/schemas/Artist/properties/id"}
         }
       ]
       responses:
         200:
           description: The actual image binary of this artist, proxied from the artist's external image URL.
           content:
-            image/*: { }
+            image/*: {}
         404:
           description: The artist does not have an associated image
           content:
@@ -372,7 +372,7 @@ paths:
 
   /albums:
     get:
-      tags: [ Albums ]
+      tags: [Albums]
       summary: List Albums
       security:
         - basic: [library:read]
@@ -420,7 +420,7 @@ paths:
 
   /albums/{id}:
     get:
-      tags: [ Albums ]
+      tags: [Albums]
       summary: Get Album
       security:
         - basic: [library:read]
@@ -430,7 +430,7 @@ paths:
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Album/properties/id" }
+          schema: {$ref: "#/components/schemas/Album/properties/id"}
         }
       ]
       responses:
@@ -453,7 +453,7 @@ paths:
 
   /albums/{id}/tracks:
     get:
-      tags: [ Albums ]
+      tags: [Albums]
       summary: List Tracks in Album
       description: The tracks are always sorted by `Track#track.no` (if available).
       security:
@@ -464,7 +464,7 @@ paths:
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Album/properties/id" }
+          schema: {$ref: "#/components/schemas/Album/properties/id"}
         },
         {
           in: query,
@@ -508,7 +508,7 @@ paths:
 
   /albums/{id}/image:
     get:
-      tags: [ Albums ]
+      tags: [Albums]
       summary: Get Image of Album
       description: The image is obtained from the metadata of one of the first 5 tracks in the album.
       security:
@@ -519,14 +519,14 @@ paths:
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Album/properties/id" }
+          schema: {$ref: "#/components/schemas/Album/properties/id"}
         }
       ]
       responses:
         200:
           description: The actual image binary for this album
           content:
-            image/*: { }
+            image/*: {}
         404:
           description: The album does not have an associated image
           content:
@@ -540,7 +540,7 @@ paths:
 
   /tracks:
     get:
-      tags: [ Tracks ]
+      tags: [Tracks]
       summary: List Tracks
       security:
         - basic: [library:read]
@@ -607,7 +607,7 @@ paths:
 
   /tracks/{id}:
     get:
-      tags: [ Tracks ]
+      tags: [Tracks]
       summary: Get Track
       security:
         - basic: [library:read]
@@ -617,7 +617,7 @@ paths:
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Track/properties/id" }
+          schema: {$ref: "#/components/schemas/Track/properties/id"}
         }
       ]
       responses:
@@ -640,7 +640,7 @@ paths:
 
   /tracks/{id}/audio:
     get:
-      tags: [ Tracks ]
+      tags: [Tracks]
       summary: Get Audio of Track
       security:
         - basic: [library:read]
@@ -650,35 +650,35 @@ paths:
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Track/properties/id" }
+          schema: {$ref: "#/components/schemas/Track/properties/id"}
         }
       ]
       responses:
         200:
           description: The actual binary audio of the track
           content:
-            audio/aiff: { }
-            audio/aac: { }
-            audio/ape: { }
-            audio/asf: { }
-            audio/x-bwf: { }
-            audio/x-dff: { }
-            audio/x-dsf: { }
-            audio/flac: { }
-            audio/mpeg: { }
-            audio/x-matroska: { }
-            video/x-matroska: { }
-            audio/musepack: { }
-            audio/mp4: { }
-            audio/ogg: { }
-            audio/opus: { }
-            audio/speex: { }
-            video/ogg: { }
-            audio/vorbis: { }
-            audio/wav: { }
-            audio/webm: { }
-            audio/wavpack: { }
-            audio/x-ms-wma: { }
+            audio/aiff: {}
+            audio/aac: {}
+            audio/ape: {}
+            audio/asf: {}
+            audio/x-bwf: {}
+            audio/x-dff: {}
+            audio/x-dsf: {}
+            audio/flac: {}
+            audio/mpeg: {}
+            audio/x-matroska: {}
+            video/x-matroska: {}
+            audio/musepack: {}
+            audio/mp4: {}
+            audio/ogg: {}
+            audio/opus: {}
+            audio/speex: {}
+            video/ogg: {}
+            audio/vorbis: {}
+            audio/wav: {}
+            audio/webm: {}
+            audio/wavpack: {}
+            audio/x-ms-wma: {}
         401:
           $ref: "#/components/responses/Unauthorised"
         403:
@@ -686,7 +686,7 @@ paths:
 
   /tracks/{id}/image:
     get:
-      tags: [ Tracks ]
+      tags: [Tracks]
       summary: Get Image of Track
       description: Obtained from the track metadata
       security:
@@ -697,14 +697,14 @@ paths:
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Track/properties/id" }
+          schema: {$ref: "#/components/schemas/Track/properties/id"}
         }
       ]
       responses:
         200:
           description: The actual image binary for this track
           content:
-            image/*: { }
+            image/*: {}
         404:
           description: The track does not have an associated image
           content:
@@ -718,11 +718,11 @@ paths:
 
   /users:
     get:
-      tags: [ Users ]
+      tags: [Users]
       summary: List Users
       security:
-        - basic: [ users:read ]
-        - bearer: [ users:read ]
+        - basic: [users:read]
+        - bearer: [users:read]
       parameters: [
         {
           in: query,
@@ -764,11 +764,11 @@ paths:
         403:
           $ref: "#/components/responses/Forbidden"
     post:
-      tags: [ Users ]
+      tags: [Users]
       summary: Create User
       security:
-        - basic: [ users:write ]
-        - bearer: [ users:write ]
+        - basic: [users:write]
+        - bearer: [users:write]
       requestBody:
         $ref: "#/components/requestBodies/User"
       responses:
@@ -783,12 +783,12 @@ paths:
         403:
           $ref: "#/components/responses/Forbidden"
     delete:
-      tags: [ Users ]
+      tags: [Users]
       summary: Delete All Users
       description: Will delete all users and all tokens.
       security:
-        - basic: [ users:write ]
-        - bearer: [ users:write ]
+        - basic: [users:write]
+        - bearer: [users:write]
       responses:
         204:
           description: All users deleted successfully
@@ -799,17 +799,17 @@ paths:
 
   /users/{id}:
     get:
-      tags: [ Users ]
+      tags: [Users]
       summary: Get User
       security:
-        - basic: [ users:read ]
-        - bearer: [ users:read ]
+        - basic: [users:read]
+        - bearer: [users:read]
       parameters: [
         {
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/User/properties/id" }
+          schema: {$ref: "#/components/schemas/User/properties/id"}
         }
       ]
       responses:
@@ -830,17 +830,17 @@ paths:
         403:
           $ref: "#/components/responses/Forbidden"
     delete:
-      tags: [ Users ]
+      tags: [Users]
       summary: Delete User
       security:
-        - basic: [ users:write ]
-        - bearer: [ users:write ]
+        - basic: [users:write]
+        - bearer: [users:write]
       parameters: [
         {
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/User/properties/id" }
+          schema: {$ref: "#/components/schemas/User/properties/id"}
         }
       ]
       responses:
@@ -851,17 +851,17 @@ paths:
         403:
           $ref: "#/components/responses/Forbidden"
     put:
-      tags: [ Users ]
+      tags: [Users]
       summary: Update User
       security:
-        - basic: [ users:write ]
-        - bearer: [ users:write ]
+        - basic: [users:write]
+        - bearer: [users:write]
       parameters: [
         {
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/User/properties/id" }
+          schema: {$ref: "#/components/schemas/User/properties/id"}
         }
       ]
       requestBody:
@@ -884,17 +884,17 @@ paths:
         403:
           $ref: "#/components/responses/Forbidden"
     patch:
-      tags: [ Users ]
+      tags: [Users]
       summary: Partially Update User
       security:
-        - basic: [ users:write ]
-        - bearer: [ users:write ]
+        - basic: [users:write]
+        - bearer: [users:write]
       parameters: [
         {
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/User/properties/id" }
+          schema: {$ref: "#/components/schemas/User/properties/id"}
         }
       ]
       requestBody:
@@ -915,13 +915,13 @@ paths:
 
   /tokens:
     get:
-      tags: [ Tokens ]
+      tags: [Tokens]
       summary: List Tokens
       security:
-        - basic: [ tokens:read:self ]
-        - bearer: [ tokens:read:self ]
-        - basic: [ tokens:read:all ]
-        - bearer: [ tokens:read:all ]
+        - basic: [tokens:read:self]
+        - bearer: [tokens:read:self]
+        - basic: [tokens:read:all]
+        - bearer: [tokens:read:all]
       parameters: [
         {
           in: query,
@@ -977,19 +977,19 @@ paths:
         403:
           $ref: "#/components/responses/Forbidden"
     post:
-      tags: [ Tokens ]
+      tags: [Tokens]
       summary: Create Token
       security:
-        - basic: [ tokens:write:self ]
-        - bearer: [ tokens:write:self ]
-        - basic: [ tokens:write:all ]
-        - bearer: [ tokens:write:all ]
+        - basic: [tokens:write:self]
+        - bearer: [tokens:write:self]
+        - basic: [tokens:write:all]
+        - bearer: [tokens:write:all]
       requestBody:
         content:
           application/json:
             schema:
               type: object
-              required: [ user, expires, scopes, note ]
+              required: [user, expires, scopes, note]
               properties:
                 user:
                   description: The ID of the user to create this token for. You can only use this if you have the `tokens:write:all` scope.
@@ -1004,7 +1004,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               type: object
-              required: [ user, expires, scopes, note ]
+              required: [user, expires, scopes, note]
               properties:
                 user:
                   description: The ID of the user to create this token for. You can only use this if you have the `tokens:write:all` scope.
@@ -1035,13 +1035,13 @@ paths:
         403:
           $ref: "#/components/responses/Forbidden"
     delete:
-      tags: [ Tokens ]
+      tags: [Tokens]
       summary: Delete All Tokens
       security:
-        - basic: [ tokens:write:self ]
-        - bearer: [ tokens:write:self ]
-        - basic: [ tokens:write:all ]
-        - bearer: [ tokens:write:all ]
+        - basic: [tokens:write:self]
+        - bearer: [tokens:write:self]
+        - basic: [tokens:write:all]
+        - bearer: [tokens:write:all]
       responses:
         204:
           description: All tokens deleted successfully
@@ -1052,19 +1052,19 @@ paths:
 
   /tokens/{id}:
     get:
-      tags: [ Tokens ]
+      tags: [Tokens]
       summary: Get Token
       security:
-        - basic: [ tokens:read:self ]
-        - bearer: [ tokens:read:self ]
-        - basic: [ tokens:read:all ]
-        - bearer: [ tokens:read:all ]
+        - basic: [tokens:read:self]
+        - bearer: [tokens:read:self]
+        - basic: [tokens:read:all]
+        - bearer: [tokens:read:all]
       parameters: [
         {
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Token/properties/id" }
+          schema: {$ref: "#/components/schemas/Token/properties/id"}
         }
       ]
       responses:
@@ -1085,19 +1085,19 @@ paths:
         403:
           $ref: "#/components/responses/Forbidden"
     delete:
-      tags: [ Tokens ]
+      tags: [Tokens]
       summary: Delete Token
       security:
-        - basic: [ tokens:write:self ]
-        - bearer: [ tokens:write:self ]
-        - basic: [ tokens:write:all ]
-        - bearer: [ tokens:write:all ]
+        - basic: [tokens:write:self]
+        - bearer: [tokens:write:self]
+        - basic: [tokens:write:all]
+        - bearer: [tokens:write:all]
       parameters: [
         {
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Token/properties/id" }
+          schema: {$ref: "#/components/schemas/Token/properties/id"}
         }
       ]
       responses:
@@ -1114,19 +1114,19 @@ paths:
         403:
           $ref: "#/components/responses/Forbidden"
     put:
-      tags: [ Tokens ]
+      tags: [Tokens]
       summary: Update Token
       security:
-        - basic: [ tokens:write:self ]
-        - bearer: [ tokens:write:self ]
-        - basic: [ tokens:write:all ]
-        - bearer: [ tokens:write:all ]
+        - basic: [tokens:write:self]
+        - bearer: [tokens:write:self]
+        - basic: [tokens:write:all]
+        - bearer: [tokens:write:all]
       parameters: [
         {
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Token/properties/id" }
+          schema: {$ref: "#/components/schemas/Token/properties/id"}
         }
       ]
       requestBody:
@@ -1134,14 +1134,14 @@ paths:
           application/json:
             schema:
               type: object
-              required: [ note ]
+              required: [note]
               properties:
                 note:
                   $ref: "#/components/schemas/Token/properties/note"
           application/x-www-form-urlencoded:
             schema:
               type: object
-              required: [ note ]
+              required: [note]
               properties:
                 note:
                   $ref: "#/components/schemas/Token/properties/note"
@@ -1163,19 +1163,19 @@ paths:
         403:
           $ref: "#/components/responses/Forbidden"
     patch:
-      tags: [ Tokens ]
+      tags: [Tokens]
       summary: Partially Update Token
       security:
-        - basic: [ tokens:write:self ]
-        - bearer: [ tokens:write:self ]
-        - basic: [ tokens:write:all ]
-        - bearer: [ tokens:write:all ]
+        - basic: [tokens:write:self]
+        - bearer: [tokens:write:self]
+        - basic: [tokens:write:all]
+        - bearer: [tokens:write:all]
       parameters: [
         {
           in: path,
           name: id,
           required: true,
-          schema: { $ref: "#/components/schemas/Token/properties/id" }
+          schema: {$ref: "#/components/schemas/Token/properties/id"}
         }
       ]
       requestBody:
@@ -1290,7 +1290,7 @@ components:
         album:
           description: This is nullable as tracks are not required to be part of an album.
           allOf: [
-            { $ref: "#/components/schemas/Album/properties/id" }
+            {$ref: "#/components/schemas/Album/properties/id"}
           ]
           nullable: true
         year:
@@ -1407,7 +1407,7 @@ components:
     Scope:
       description: Controls access to API resources
       type: string
-      enum: [ library:read, library:write, tokens:read:self, tokens:write:self, tokens:read:all, tokens:write:all, users:read, users:write ]
+      enum: [library:read, library:write, tokens:read:self, tokens:write:self, tokens:read:all, tokens:write:all, users:read, users:write]
 
     Page<T>:
       description: A page is a partial list of items from a larger collection
@@ -1459,11 +1459,11 @@ components:
     BooleanLike:
       oneOf:
         - type: boolean
-          enum: [ true, false ]
+          enum: [true, false]
         - type: string
-          enum: [ "true", "false", "1", "0", "on" ]
+          enum: ["true", "false", "1", "0", "on"]
         - type: integer
-          enum: [ 1, 0 ]
+          enum: [1, 0]
       example: false
 
     UserWrite:
@@ -1487,10 +1487,10 @@ components:
           schema:
             allOf:
               - $ref: "#/components/schemas/UserWrite"
-            required: [ username, password, scopes, disabled ]
+            required: [username, password, scopes, disabled]
         application/x-www-form-urlencoded:
           schema:
             allOf:
               - $ref: "#/components/schemas/UserWrite"
-            required: [ username, password, scopes, disabled ]
+            required: [username, password, scopes, disabled]
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -912,6 +912,16 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/User"
+        404:
+          description: The requested user could not be found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /tokens:
     get:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -153,6 +153,10 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/Artist"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /artists/{id}:
     get:
@@ -182,6 +186,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /artists/{id}/albums:
     get:
@@ -232,6 +240,10 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/Album"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /artists/{id}/tracks:
     get:
@@ -282,6 +294,10 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/Track"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /artists/{id}/image:
     get:
@@ -315,6 +331,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /albums:
     get:
@@ -359,6 +379,10 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/Album"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /albums/{id}:
     get:
@@ -388,6 +412,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /albums/{id}/tracks:
     get:
@@ -439,6 +467,10 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/Track"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /albums/{id}/image:
     get:
@@ -467,6 +499,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /tracks:
     get:
@@ -530,6 +566,10 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/Track"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /tracks/{id}:
     get:
@@ -559,6 +599,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /tracks/{id}/audio:
     get:
@@ -601,6 +645,10 @@ paths:
             audio/webm: { }
             audio/wavpack: { }
             audio/x-ms-wma: { }
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
   /tracks/{id}/image:
     get:
@@ -629,6 +677,10 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
 
 components:
   securitySchemes:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "GPL-3.0-only",
       "dependencies": {
+        "argon2": "^0.40.3",
         "better-sqlite3": "^11.1.2",
         "enhanced-switch": "^1.1.7",
         "json5": "^2.2.3",
@@ -20,6 +21,15 @@
         "@types/better-sqlite3": "^7.6.11",
         "@types/node": "^20.14.11",
         "typescript": "^5.5.3"
+      }
+    },
+    "node_modules/@phc/format": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@phc/format/-/format-1.0.0.tgz",
+      "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@tokenizer/token": {
@@ -44,6 +54,21 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/argon2": {
+      "version": "0.40.3",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.40.3.tgz",
+      "integrity": "sha512-FrSmz4VeM91jwFvvjsQv9GYp6o/kARWoYKjbjDB2U5io1H3e5X67PYGclFDeQff6UXIhUd4aHR3mxCdBbMMuQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@phc/format": "^1.0.0",
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.0"
+      },
+      "engines": {
+        "node": ">=16.17.0"
       }
     },
     "node_modules/base64-js": {
@@ -389,6 +414,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.1.0.tgz",
+      "integrity": "sha512-yBY+qqWSv3dWKGODD6OGE6GnTX7Q2r+4+DfpqxHSHh8x0B4EKP9+wVGLS6U/AM1vxSNNmUEuIV5EGhYwPpfOwQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
+      "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/once": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "typescript": "^5.5.3"
   },
   "dependencies": {
+    "argon2": "^0.40.3",
     "better-sqlite3": "^11.1.2",
     "enhanced-switch": "^1.1.7",
     "json5": "^2.2.3",

--- a/src/Authorisation.ts
+++ b/src/Authorisation.ts
@@ -1,0 +1,74 @@
+import User from "./resource/User.js";
+import Token from "./resource/Token.js";
+import Library from "./Library.js";
+import ApiRequest from "./api/ApiRequest.js";
+import ThrowableResponse from "./response/ThrowableResponse.js";
+import ErrorResponse from "./response/ErrorResponse.js";
+
+export default class Authorisation {
+    public constructor(
+        public readonly user: User,
+        public readonly scopes: Readonly<Set<Token.Scope>>,
+        public readonly expires: Date | null
+    ) {
+    }
+
+    public require(scope: Token.Scope): void {
+        if (!this.scopes.has(scope)) throw new ThrowableResponse(Authorisation.FORBIDDEN);
+    }
+
+    public static fromToken(secret: Token.Secret, library: Library): Authorisation | null {
+        const token = library.repositories.tokens.getBySecret(secret);
+        if (token === null) return null;
+        const user = library.repositories.users.get(token.user);
+        if (user === null) {
+            library.repositories.tokens.delete(token.id);
+            return null;
+        }
+        if (user.disabled) return null;
+        return new Authorisation(user, Object.freeze(token.scopes), token.expires);
+    }
+
+    public static fromUser(user: User): Authorisation | null {
+        if (user.disabled) return null;
+        return new Authorisation(user, Object.freeze(user.scopes), null);
+    }
+
+    public static async fromBasic(username: string, password: string, library: Library): Promise<Authorisation | null> {
+        const user = library.repositories.users.getByUsername(username);
+        if (user === null) return null;
+        if (!await user.password.verify(password)) return null;
+        return this.fromUser(user);
+    }
+
+    public static async fromHeader(header: string, library: Library): Promise<Authorisation | null> {
+        const [scheme] = header.split(" ");
+        if (scheme === undefined) return null;
+        const value = header.slice(scheme.length + 1);
+        switch (scheme.toLowerCase()) {
+            case "bearer":
+                return this.fromToken(new Token.Secret(value), library);
+            case "basic": {
+                const credentials = Buffer.from(value, "base64").toString("utf8");
+                const [username] = credentials.split(":");
+                if (username === undefined) return null;
+                const password = credentials.slice(username.length + 1);
+                return await this.fromBasic(username, password, library);
+            }
+            default:
+                return null;
+        }
+    }
+
+    public static async fromReq(req: ApiRequest, library: Library): Promise<Authorisation | null> {
+        const header = req.headers.authorization;
+        if (header === undefined) return null;
+        return await this.fromHeader(header, library);
+    }
+
+    public static readonly UNAUTHORISED = new ErrorResponse(401, "Authorisation is required to access this endpoint.", {
+        "WWW-Authenticate": 'Basic realm="Prelude API", Bearer realm="Prelude API"'
+    });
+
+    public static readonly FORBIDDEN = new ErrorResponse(403, "You don't have permission to access this endpoint.");
+}

--- a/src/Authorisation.ts
+++ b/src/Authorisation.ts
@@ -8,8 +8,7 @@ import ErrorResponse from "./response/ErrorResponse.js";
 export default class Authorisation {
     public constructor(
         public readonly user: User,
-        public readonly scopes: Readonly<Set<Token.Scope>>,
-        public readonly expires: Date | null
+        public readonly scopes: Readonly<Set<Token.Scope>>
     ) {
     }
 
@@ -19,19 +18,19 @@ export default class Authorisation {
 
     public static fromToken(secret: Token.Secret, library: Library): Authorisation | null {
         const token = library.repositories.tokens.getBySecret(secret);
-        if (token === null) return null;
+        if (token === null || token.expired) return null;
         const user = library.repositories.users.get(token.user);
         if (user === null) {
             library.repositories.tokens.delete(token.id);
             return null;
         }
         if (user.disabled) return null;
-        return new Authorisation(user, Object.freeze(token.scopes), token.expires);
+        return new Authorisation(user, Object.freeze(token.scopes));
     }
 
     public static fromUser(user: User): Authorisation | null {
         if (user.disabled) return null;
-        return new Authorisation(user, Object.freeze(user.scopes), null);
+        return new Authorisation(user, Object.freeze(user.scopes));
     }
 
     public static async fromBasic(username: string, password: string, library: Library): Promise<Authorisation | null> {

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -32,16 +32,23 @@ export default class Config {
      */
     public readonly db: File;
 
+    /**
+     * Minimum password length for users
+     */
+    public readonly minPasswordLength: number;
+
     public constructor(options: {
         port?: typeof Config.prototype.port,
         discoverPaths?: typeof Config.prototype.discoverPaths,
         unknownArtist?: typeof Config.prototype.unknownArtist,
         db?: typeof Config.prototype.db,
+        minPasswordLength?: number,
     }) {
         this.port = options.port ?? 9847;
         this.discoverPaths = options.discoverPaths ?? [];
         this.unknownArtist = options.unknownArtist ?? "Unknown Artist";
         this.db = options.db ?? new SystemFile("/prelude.db");
+        this.minPasswordLength = options.minPasswordLength ?? 8;
     }
 
     public static async fromFile(file: File): Promise<Config> {
@@ -70,6 +77,12 @@ export default class Config {
             if (typeof json.db !== "string")
                 throw new TypeError(`Config option "db" must be a string; got (${typeof json.db}) ${json.db}`);
             options.db = new SystemFile(json.db);
+        }
+
+        if ("minPasswordLength" in json) {
+            if (typeof json.minPasswordLength !== "number")
+                throw new TypeError(`Config option "minPasswordLength" must be a number; got (${typeof json.minPasswordLength}) ${json.minPasswordLength}`);
+            options.minPasswordLength = json.minPasswordLength;
         }
 
         return new Config(options);

--- a/src/HashID.ts
+++ b/src/HashID.ts
@@ -1,0 +1,18 @@
+import crypto from "node:crypto";
+import ID from "./ID.js";
+
+export default class HashID extends ID {
+    private static hash(string: string): string {
+        return crypto.createHash("sha1").update(string).digest("base64").replace(/=+$/, "").replace(/\/+/g, "-");
+    }
+
+    /**
+     * Calculate ID from strings/IDs
+     */
+    protected static of(...args: (string | ID | null | undefined)[]): HashID {
+        return new this(HashID.hash(args.map(s => {
+            const k = (typeof s === "string") ? s : s?.id ?? "";
+            return k.length + k;
+        }).join("")));
+    }
+}

--- a/src/ID.ts
+++ b/src/ID.ts
@@ -1,6 +1,4 @@
-import crypto from "node:crypto";
-
-export default class ID {
+export default abstract class ID {
     readonly #id: string;
 
     /**
@@ -17,25 +15,17 @@ export default class ID {
         return this.#id;
     }
 
+    /**
+     * Get string representation of this ID
+     */
     public toString(): string {
         return this.id;
     }
 
+    /**
+     * Check if another ID is for the same resource as this one
+     */
     public equals(other: ID): boolean {
         return this instanceof other.constructor && this.id === other.id;
-    }
-
-    private static hash(string: string): string {
-        return crypto.createHash("sha1").update(string).digest("base64").replace(/=+$/, "").replace(/\/+/g, "-");
-    }
-
-    /**
-     * Calculate ID from strings/IDs
-     */
-    protected static of(...args: (string | ID | null | undefined)[]): ID {
-        return new this(ID.hash(args.map(s => {
-            const k = (typeof s === "string") ? s : s?.id ?? "";
-            return k.length + k;
-        }).join("")));
     }
 }

--- a/src/ID.ts
+++ b/src/ID.ts
@@ -4,7 +4,7 @@ export default abstract class ID {
     /**
      * Create ID from the string representation of an ID.
      */
-    protected constructor(id: string) {
+    public constructor(id: string) {
         this.#id = id;
     }
 

--- a/src/Library.ts
+++ b/src/Library.ts
@@ -5,6 +5,8 @@ import Artist from "./resource/Artist.js";
 import Album from "./resource/Album.js";
 import Track from "./resource/Track.js";
 import Config from "./Config.js";
+import User from "./resource/User.js";
+import Token from "./resource/Token.js";
 
 export default class Library {
     /**
@@ -35,14 +37,16 @@ export default class Library {
         "wma"                  // WMA
     ];
 
-    public readonly repositories: { artists: Artist.Repository, albums: Album.Repository, tracks: Track.Repository };
+    public readonly repositories: { artists: Artist.Repository, albums: Album.Repository, tracks: Track.Repository, users: User.Repository, tokens: Token.Repository };
 
-    public constructor(private readonly db: Database, private readonly config: Config) {
+    public constructor(private readonly db: Database, public readonly config: Config) {
         this.db = new Database(this.config.db);
         this.repositories = {
             artists: new Artist.Repository(this.db),
             albums: new Album.Repository(this.db),
-            tracks: new Track.Repository(this.db)
+            tracks: new Track.Repository(this.db),
+            users: new User.Repository(this.db),
+            tokens: new Token.Repository(this.db),
         }
     }
 

--- a/src/Password.ts
+++ b/src/Password.ts
@@ -1,0 +1,21 @@
+import argon2 from "argon2";
+
+/**
+ * A password hash
+ */
+export default class Password {
+    public constructor(public readonly hash: string) {}
+
+    public async verify(password: string): Promise<boolean> {
+        return await argon2.verify(this.hash, password);
+    }
+
+    public static async hash(password: string): Promise<Password> {
+        return new this(await argon2.hash(password, {
+            type: argon2.argon2id,
+            memoryCost: 2**16, // 64 MB
+            timeCost: 3, // iterations
+            parallelism: 1, // threads
+        }));
+    }
+}

--- a/src/RandomID.ts
+++ b/src/RandomID.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import ID from "./ID.js";
 
 export default class RandomID extends ID {

--- a/src/RandomID.ts
+++ b/src/RandomID.ts
@@ -1,0 +1,7 @@
+import ID from "./ID.js";
+
+export default class RandomID extends ID {
+    public static random(): RandomID {
+        return new this(crypto.randomUUID());
+    }
+}

--- a/src/Server.ts
+++ b/src/Server.ts
@@ -4,6 +4,7 @@ import Config from "./Config.js";
 import Api from "./api/Api.js";
 import JsonResponse from "./response/JsonResponse.js";
 import Controller from "./api/Controller.js";
+import Library from "./Library.js";
 
 export default class Server {
     private readonly http: http.Server;
@@ -12,8 +13,9 @@ export default class Server {
         public readonly config: Config,
         packageJson: JsonResponse.Object,
         controllers: Controller[],
+        library: Library
     ) {
-        const api = new Api(controllers,packageJson);
+        const api = new Api(controllers, packageJson, library);
         this.http = http.createServer<typeof http.IncomingMessage, typeof http.ServerResponse>(api.requestListener.bind(api));
     }
 

--- a/src/api/ResourceController.ts
+++ b/src/api/ResourceController.ts
@@ -26,7 +26,7 @@ export default abstract class ResourceController extends Controller {
      *
      * Get resources
      */
-    protected list(req: ApiRequest, _urlParts: string[]): ApiResponse {
+    protected list(req: ApiRequest, _urlParts: string[]): ApiResponse | Promise<ApiResponse> {
         return Controller.methodNotAllowed(req);
     }
 
@@ -35,7 +35,7 @@ export default abstract class ResourceController extends Controller {
      *
      * Create resource
      */
-    protected create(req: ApiRequest, _urlParts: string[]): ApiResponse {
+    protected create(req: ApiRequest, _urlParts: string[]): ApiResponse | Promise<ApiResponse> {
         return Controller.methodNotAllowed(req);
     }
 
@@ -44,7 +44,7 @@ export default abstract class ResourceController extends Controller {
      *
      * Delete all resources
      */
-    protected deleteAll(req: ApiRequest, _urlParts: string[]): ApiResponse {
+    protected deleteAll(req: ApiRequest, _urlParts: string[]): ApiResponse | Promise<ApiResponse> {
         return Controller.methodNotAllowed(req);
     }
 
@@ -53,7 +53,7 @@ export default abstract class ResourceController extends Controller {
      *
      * Get resource
      */
-    protected get(req: ApiRequest, _id: string, _urlParts: string[]): ApiResponse {
+    protected get(req: ApiRequest, _id: string, _urlParts: string[]): ApiResponse | Promise<ApiResponse> {
         return Controller.methodNotAllowed(req);
     }
 
@@ -62,7 +62,7 @@ export default abstract class ResourceController extends Controller {
      *
      * Delete resource
      */
-    protected delete(req: ApiRequest, _id: string, _urlParts: string[]): ApiResponse {
+    protected delete(req: ApiRequest, _id: string, _urlParts: string[]): ApiResponse | Promise<ApiResponse> {
         return Controller.methodNotAllowed(req);
     }
 
@@ -71,7 +71,7 @@ export default abstract class ResourceController extends Controller {
      *
      * Replace resource
      */
-    protected put(req: ApiRequest, _id: string, _urlParts: string[]): ApiResponse {
+    protected put(req: ApiRequest, _id: string, _urlParts: string[]): ApiResponse | Promise<ApiResponse> {
         return Controller.methodNotAllowed(req);
     }
 
@@ -80,24 +80,24 @@ export default abstract class ResourceController extends Controller {
      *
      * Update resource
      */
-    protected patch(req: ApiRequest, _id: string, _urlParts: string[]): ApiResponse {
+    protected patch(req: ApiRequest, _id: string, _urlParts: string[]): ApiResponse | Promise<ApiResponse> {
         return Controller.methodNotAllowed(req);
     }
 
-    public override handle(req: ApiRequest, urlParts: string[]): Promise<ApiResponse> | ApiResponse {
+    public override async handle(req: ApiRequest, urlParts: string[]): Promise<ApiResponse> {
         if (urlParts.length === this.pathStartIndex + 1) switch (req.method) {
-            case "GET": return this.list(req, urlParts);
-            case "POST": return this.create(req, urlParts);
-            case "DELETE": return this.deleteAll(req, urlParts);
+            case "GET": case "HEAD": return await this.list(req, urlParts);
+            case "POST": return await this.create(req, urlParts);
+            case "DELETE": return await this.deleteAll(req, urlParts);
             default: return Controller.methodNotAllowed(req);
         }
         if (urlParts.length === this.pathStartIndex + 2) {
             const id = urlParts[this.pathStartIndex + 1]!;
             switch (req.method) {
-                case "GET": return this.get(req, id, urlParts);
-                case "DELETE": return this.delete(req, id, urlParts);
-                case "PUT": return this.put(req, id, urlParts);
-                case "PATCH": return this.patch(req, id, urlParts);
+                case "GET": case "HEAD": return await this.get(req, id, urlParts);
+                case "DELETE": return await this.delete(req, id, urlParts);
+                case "PUT": return await this.put(req, id, urlParts);
+                case "PATCH": return await this.patch(req, id, urlParts);
                 default: return Controller.methodNotAllowed(req);
             }
         }

--- a/src/db/init.sql
+++ b/src/db/init.sql
@@ -36,3 +36,27 @@ CREATE TABLE IF NOT EXISTS `tracks`
 
 CREATE INDEX IF NOT EXISTS `track_artist` ON `tracks` (`artist`);
 CREATE INDEX IF NOT EXISTS `track_album` ON `tracks` (`album`);
+
+CREATE TABLE IF NOT EXISTS `users`
+(
+    `id`       CHAR(36) PRIMARY KEY NOT NULL COLLATE nocase,
+    `username` VARCHAR(24)          NOT NULL COLLATE nocase,
+    `scopes`   TEXT                 NOT NULL COLLATE nocase,
+    `password` TEXT                 NOT NULL COLLATE nocase,
+    `disabled` BOOLEAN              NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS `users_username` ON `users` (`username`);
+
+CREATE TABLE IF NOT EXISTS `tokens`
+(
+    `id`      CHAR(36) PRIMARY KEY NOT NULL COLLATE nocase,
+    `user`    CHAR(36)             NOT NULL COLLATE nocase,
+    `secret`  CHAR(36)             NOT NULL COLLATE binary,
+    `scopes`  TEXT                 NOT NULL COLLATE nocase,
+    `expires` DATETIME             NULL,
+    `note`    VARCHAR(128)         NOT NULL COLLATE nocase,
+    FOREIGN KEY (`user`) REFERENCES `users` (`id`)
+);
+
+CREATE INDEX IF NOT EXISTS `tokens_user` ON `tokens` (`user`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import Album from "./resource/Album.js";
 import Track from "./resource/Track.js";
 import User from "./resource/User.js";
 import Token from "./resource/Token.js";
+import Password from "./Password.js";
 
 const configArgIndex = process.argv.findIndex(arg => arg === "--config" || arg === "-c");
 const customConfig = configArgIndex >= 0 && process.argv.length > configArgIndex + 1;
@@ -51,6 +52,22 @@ console.log(`Server listening on http://0.0.0.0:${config.port}`);
 console.log("Reloading library... (this may take a while)");
 const libLoad = await library.reload();
 console.log(`Library loaded. Added ${libLoad.added} new track${libLoad.added === 1 ? "" : "s"}${libLoad.removed > 0 ? `, removed ${libLoad.removed} orphaned track${libLoad.removed === 1 ? "" : "s"}` : ""}.`);
+
+// if no users in db, create default admin user
+if (library.repositories.users.list({limit: 0, offset: 0}).total === 0) {
+    // using token secret generator just to get a good password
+    const password = Token.Secret.random().id;
+    library.repositories.users.save(new User(
+        User.ID.random(),
+        "admin",
+        new Set(Object.values(Token.Scope)), // all scopes
+        await Password.hash(password),
+        false
+    ));
+    console.log("Generated a default administrator user:");
+    console.log("Username: admin");
+    console.log("Password: " + password);
+}
 
 process.on("SIGINT", async () => {
     console.log("\rStopping...");

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import Database from "./db/Database.js";
 import Artist from "./resource/Artist.js";
 import Album from "./resource/Album.js";
 import Track from "./resource/Track.js";
+import User from "./resource/User.js";
+import Token from "./resource/Token.js";
 
 const configArgIndex = process.argv.findIndex(arg => arg === "--config" || arg === "-c");
 const customConfig = configArgIndex >= 0 && process.argv.length > configArgIndex + 1;
@@ -41,7 +43,9 @@ const server = await new Server(config, packageJson, [
     new Artist.Controller(library),
     new Album.Controller(library),
     new Track.Controller(library),
-]).listen();
+    new User.Controller(library),
+    new Token.Controller(library),
+], library).listen();
 console.log(`Server listening on http://0.0.0.0:${config.port}`);
 
 console.log("Reloading library... (this may take a while)");

--- a/src/resource/Album.ts
+++ b/src/resource/Album.ts
@@ -1,4 +1,4 @@
-import ID_ from "../ID.js";
+import HashID from "../HashID.js";
 import Artist from "./Artist.js";
 import JsonResponse from "../response/JsonResponse.js";
 import Repository_ from "../Repository.js";
@@ -31,7 +31,7 @@ class Album extends ApiResource {
 }
 
 namespace Album {
-    export class ID extends ID_ {
+    export class ID extends HashID {
         public constructor(id: string) {
             super(id);
         }

--- a/src/resource/Album.ts
+++ b/src/resource/Album.ts
@@ -11,6 +11,7 @@ import PageResponse from "../response/PageResponse.js";
 import ErrorResponse from "../response/ErrorResponse.js";
 import Library from "../Library.js";
 import BufferResponse from "../response/BufferResponse.js";
+import Token from "./Token.js";
 
 class Album extends ApiResource {
     public constructor(
@@ -94,12 +95,14 @@ namespace Album {
         ]
 
         protected override list(req: ApiRequest): ApiResponse {
+            req.require(Token.Scope.LIBRARY_READ);
             const limit = req.limit();
             const albums = this.library.repositories.albums.list(limit);
             return new PageResponse(req, albums.resources.map(a => a.json()), limit.page, limit.limit, albums.total);
         }
 
-        protected override get(_req: ApiRequest, id: string): ApiResponse {
+        protected override get(req: ApiRequest, id: string): ApiResponse {
+            req.require(Token.Scope.LIBRARY_READ);
             const album = this.library.repositories.albums.get(new Album.ID(id));
             if (album === null) return Album.Controller.notFound();
             return new JsonResponse(album.json());
@@ -115,6 +118,7 @@ namespace Album {
         protected override readonly pathStartIndex = 2;
 
         protected override list(req: ApiRequest, urlParts: string[]): ApiResponse {
+            req.require(Token.Scope.LIBRARY_READ);
             const album = this.library.repositories.albums.get(new Album.ID(urlParts[1]!));
             if (album === null) return Album.Controller.notFound();
             const limit = req.limit();
@@ -133,7 +137,8 @@ namespace Album {
         }
 
         public override async handle(req: ApiRequest, urlParts: string[]): Promise<ApiResponse> {
-            if (req.method !== "GET") return Controller_.methodNotAllowed(req);
+            if (!["GET", "HEAD"].includes(req.method)) return Controller_.methodNotAllowed(req);
+            req.require(Token.Scope.LIBRARY_READ);
             const album = this.library.repositories.albums.get(new Album.ID(urlParts[1]!));
             if (album === null) return Album.Controller.notFound();
             const tracks = this.library.repositories.tracks.album(album.id, {limit: 5, offset: 0});

--- a/src/resource/Artist.ts
+++ b/src/resource/Artist.ts
@@ -1,4 +1,4 @@
-import ID_ from "../ID.js";
+import HashID from "../HashID.js";
 import JsonResponse from "../response/JsonResponse.js";
 import Repository_ from "../Repository.js";
 import ApiResource from "../api/ApiResource.js";
@@ -30,7 +30,7 @@ class Artist extends ApiResource {
 }
 
 namespace Artist {
-    export class ID extends ID_ {
+    export class ID extends HashID {
         public constructor(id: string) {
             super(id);
         }

--- a/src/resource/Artist.ts
+++ b/src/resource/Artist.ts
@@ -10,6 +10,7 @@ import PageResponse from "../response/PageResponse.js";
 import ErrorResponse from "../response/ErrorResponse.js";
 import Library from "../Library.js";
 import ProxyResponse from "../response/ProxyResponse.js";
+import Token from "./Token.js";
 
 class Artist extends ApiResource {
     public constructor(
@@ -95,6 +96,7 @@ namespace Artist {
         ];
 
         protected override list(req: ApiRequest): ApiResponse {
+            req.require(Token.Scope.LIBRARY_READ);
             const ids = req.url.searchParams.getAll("id");
             if (ids.length > 0) {
                 const idSet = new Set<Artist.ID>(ids.map(id => new Artist.ID(id)));
@@ -107,7 +109,8 @@ namespace Artist {
             return new PageResponse(req, artists.resources.map(a => a.json()), limit.page, limit.limit, artists.total);
         }
 
-        protected override get(_req: ApiRequest, id: string): ApiResponse {
+        protected override get(req: ApiRequest, id: string): ApiResponse {
+            req.require(Token.Scope.LIBRARY_READ);
             const artist = this.library.repositories.artists.get(new Artist.ID(id));
             if (artist === null) return Artist.Controller.notFound();
             return new JsonResponse(artist.json());
@@ -122,6 +125,7 @@ namespace Artist {
         protected override readonly path = ["artists", null, "albums"];
         protected override readonly pathStartIndex = 2;
         protected override list(req: ApiRequest, urlParts: string[]): ApiResponse {
+            req.require(Token.Scope.LIBRARY_READ);
             const artist = this.library.repositories.artists.get(new Artist.ID(urlParts[1]!));
             if (artist === null) return Artist.Controller.notFound();
             const limit = req.limit();
@@ -134,6 +138,7 @@ namespace Artist {
         protected override readonly path = ["artists", null, "tracks"];
         protected override readonly pathStartIndex = 2;
         protected override list(req: ApiRequest, urlParts: string[]): ApiResponse {
+            req.require(Token.Scope.LIBRARY_READ);
             const artist = this.library.repositories.artists.get(new Artist.ID(urlParts[1]!));
             if (artist === null) return Artist.Controller.notFound();
             const limit = req.limit();
@@ -152,7 +157,8 @@ namespace Artist {
         }
 
         public override async handle(req: ApiRequest, urlParts: string[]): Promise<ApiResponse> {
-            if (req.method !== "GET") return Controller_.methodNotAllowed(req);
+            if (!["GET", "HEAD"].includes(req.method)) return Controller_.methodNotAllowed(req);
+            req.require(Token.Scope.LIBRARY_READ);
             const artist = this.library.repositories.artists.get(new Artist.ID(urlParts[1]!));
             if (artist === null) return Artist.Controller.notFound();
             if (artist.externalImage === null) return ImageController.notFound(artist);

--- a/src/resource/Token.ts
+++ b/src/resource/Token.ts
@@ -322,7 +322,7 @@ namespace Token {
             this.validateScopes(req.auth, scopes);
             const token = new Token(Token.ID.random(), user.id, Token.Secret.random(), expires, scopes, note);
             this.library.repositories.tokens.save(token);
-            return new JsonResponse(token.unsafeJson());
+            return new JsonResponse(token.unsafeJson(), 201);
         }
 
         protected override deleteAll(req: ApiRequest): ApiResponse {

--- a/src/resource/Token.ts
+++ b/src/resource/Token.ts
@@ -193,7 +193,7 @@ namespace Token {
         public override list(options: {limit: number, offset: number}) {
             const rows = this.statements.list.all(options.limit, options.offset);
             return {
-                resources: rows.map(row => Token.row(row)),
+                resources: rows.map(Token.row),
                 total: this.statements.count.get()!.count
             };
         }
@@ -201,7 +201,7 @@ namespace Token {
         public listOfUser(user: User.ID, options: {limit: number, offset: number}) {
             const rows = this.statements.listOfUser.all(user.id, options.limit, options.offset);
             return {
-                resources: rows.map(row => Token.row(row)),
+                resources: rows.map(Token.row),
                 total: this.statements.count.get()!.count
             };
         }

--- a/src/resource/Token.ts
+++ b/src/resource/Token.ts
@@ -255,6 +255,7 @@ namespace Token {
             note(body: any): string {
                 if (!("note" in body)) throw new ThrowableResponse(new FieldErrorResponse({note: "Please enter a note."}));
                 if (typeof body.note !== "string") throw new ThrowableResponse(new FieldErrorResponse({note: "Must be a string."}));
+                if (body.note.length > 128) throw new ThrowableResponse(new FieldErrorResponse({note: "Must be 128 characters or less."}));
                 return body.note;
             },
             user(body: any): User.ID | null {

--- a/src/resource/Token.ts
+++ b/src/resource/Token.ts
@@ -1,0 +1,368 @@
+import crypto from "node:crypto";
+import ApiResource from "../api/ApiResource.js";
+import RandomID from "../RandomID.js";
+import User from "./User.js";
+import JsonResponse from "../response/JsonResponse.js";
+import Repository_ from "../Repository.js";
+import ResourceController from "../api/ResourceController.js";
+import ThrowableResponse from "../response/ThrowableResponse.js";
+import FieldErrorResponse from "../response/FieldErrorResponse.js";
+import ErrorResponse from "../response/ErrorResponse.js";
+import ApiRequest from "../api/ApiRequest.js";
+import PageResponse from "../response/PageResponse.js";
+import ApiResponse from "../response/ApiResponse.js";
+import Authorisation from "../Authorisation.js";
+import EmptyReponse from "../response/EmptyReponse.js";
+
+class Token extends ApiResource {
+    readonly #secret: Token.Secret;
+
+    public constructor(
+        public override readonly id: Token.ID,
+        public readonly user: User.ID,
+        secret: Token.Secret,
+        /**
+         * Date on which token expires, or `null` if it does not expire
+         */
+        public readonly expires: Date | null,
+        public readonly scopes: Set<Token.Scope>,
+        /**
+         * User-provided note
+         */
+        public note: string
+    ) {
+        super();
+        this.#secret = secret;
+    }
+
+    public get secret(): Token.Secret {
+        return this.#secret;
+    }
+
+    /**
+     * JSON representation of the token. Does not include the secret key.
+     */
+    public override json(): JsonResponse.Object {
+        return {
+            id: this.id.id,
+            user: this.user.id,
+            expires: this.expires,
+            scopes: Array.from(this.scopes.values()),
+            note: this.note
+        }
+    }
+
+    /**
+     * JSON representation of the token, including the secret key.
+     */
+    public unsafeJson(): JsonResponse.Object {
+        return {
+            id: this.id.id,
+            user: this.user.id,
+            secret: this.secret.id,
+            expires: this.expires,
+            scopes: Array.from(this.scopes.values()),
+            note: this.note
+        }
+    }
+
+    public static row(row: Record<string, any>): Token {
+        return new Token(
+            new Token.ID(row.id),
+            new User.ID(row.user),
+            new Token.Secret(row.secret),
+            row.expires === null ? null : new Date(row.expires),
+            new Set(JSON.parse(row.scopes) as Token.Scope[]),
+            row.note
+        );
+    }
+}
+
+namespace Token {
+    export class ID extends RandomID {
+        public static override random(): Token.ID {
+            return new this(super.random().id);
+        }
+    }
+
+    export class Secret extends RandomID {
+        public static override random(): Token.Secret {
+            return new this(this.generate(36));
+        }
+
+        private static characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        private static generate(length: number): string {
+            const characters: string[] = [];
+            for (let i = 0; i < length; ++i)
+                characters.push(Secret.characters.charAt(crypto.randomInt(0, Secret.characters.length)));
+            return characters.join("");
+        }
+    }
+
+    /**
+     * The token scopes specify which resources the token can read/write.
+     */
+    export enum Scope {
+        /**
+         * Read-only access to {@link Artist}, {@link Album} and {@link Track}.
+         *
+         * Recommended for: everyone
+         */
+        LIBRARY_READ = "library:read",
+
+        /**
+         * Write/modify access to {@link Artist}, {@link Album} and {@link Track}.
+         * This allows the user to upload/delete audio files to/from the server.
+         *
+         * Recommended for: admin
+         */
+        LIBRARY_WRITE = "library:write",
+
+        /**
+         * Read-only access to your {@link Token}s
+         *
+         * Recommended for: everyone
+         */
+        TOKENS_READ_SELF = "tokens:read:self",
+
+        /**
+         * Write/modify access to your {@link Token}s
+         *
+         * Recommended for: everyone
+         */
+        TOKENS_WRITE_SELF = "tokens:write:self",
+
+        /**
+         * Read-only access to everyone's {@link Token}s
+         *
+         * Recommended for: admin
+         */
+        TOKENS_READ_ALL = "tokens:read:all",
+
+        /**
+         * Write/modify access to everyone's {@link Token}s
+         *
+         * Recommended for: admin
+         */
+        TOKENS_WRITE_ALL = "tokens:write:all",
+
+        /**
+         * Read-only access to {@link User}s
+         *
+         * Recommended for: admin
+         */
+        USERS_READ = "users:read",
+
+        /**
+         * Write/modify access to {@link User}s
+         *
+         * Recommended for: admin
+         */
+        USERS_WRITE = "users:write"
+    }
+
+    export class Repository extends Repository_<Token> {
+        private readonly statements = {
+            get: this.database.prepare<[string], Record<string, any>>("SELECT * FROM `tokens` WHERE `id` = ?"),
+            getBySecret: this.database.prepare<[string], Record<string, any>>("SELECT * FROM `tokens` WHERE `secret` = ?"),
+            save: this.database.prepare<[string, string, string, number | null, string, string]>("REPLACE INTO `tokens` (`id`, `user`, `secret`, `expires`, `scopes`, `note`) VALUES (?, ?, ?, ?, ?, ?)"),
+            deleteAll: this.database.prepare<[], void>("DELETE FROM `tokens`"),
+            list: this.database.prepare<[number, number], Record<string, any>>("SELECT * FROM `tokens` LIMIT ? OFFSET ?"),
+            listOfUser: this.database.prepare<[string, number, number], Record<string, any>>("SELECT * FROM `tokens` WHERE `user` = ? LIMIT ? OFFSET ?"),
+            count: this.database.prepare<[], { count: number }>("SELECT COUNT(*) as count FROM `tokens`"),
+            delete: this.database.prepare<[string], void>("DELETE FROM `tokens` WHERE `id` = ?"),
+            deleteOfUser: this.database.prepare<[string], void>("DELETE FROM `tokens` WHERE `user` = ?"),
+        } as const;
+
+        public override get(id: Token.ID) {
+            const row = this.statements.get.get(id.id);
+            if (row === undefined) return null;
+            return Token.row(row);
+        }
+
+        public getBySecret(secret: Token.Secret) {
+            const row = this.statements.getBySecret.get(secret.id);
+            if (row === undefined) return null;
+            return Token.row(row);
+        }
+
+        public override list(options: {limit: number, offset: number}) {
+            const rows = this.statements.list.all(options.limit, options.offset);
+            return {
+                resources: rows.map(row => Token.row(row)),
+                total: this.statements.count.get()!.count
+            };
+        }
+
+        public listOfUser(user: User.ID, options: {limit: number, offset: number}) {
+            const rows = this.statements.listOfUser.all(user.id, options.limit, options.offset);
+            return {
+                resources: rows.map(row => Token.row(row)),
+                total: this.statements.count.get()!.count
+            };
+        }
+
+        public override save(resource: Token) {
+            this.statements.save.run(
+                resource.id.id,
+                resource.user.id,
+                resource.secret.id,
+                resource.expires === null ? null : resource.expires.getTime(),
+                JSON.stringify(Array.from(resource.scopes.values())),
+                resource.note
+            );
+        }
+
+        public deleteAll() {
+            this.statements.deleteAll.run();
+        }
+
+        public deleteOfUser(user: User.ID) {
+            this.statements.deleteOfUser.run(user.id);
+        }
+
+        public override delete(id: Token.ID) {
+            this.statements.delete.run(id.id);
+        }
+    }
+
+    export class Controller extends ResourceController {
+        protected override readonly path = ["tokens"];
+        private readonly extract = {
+            expires (body: any): Date | null {
+                if (!("expires" in body)) throw new ThrowableResponse(new FieldErrorResponse({expires: "Please select a date."}));
+                if (body.expires === null || body.expires === "null") return null;
+                const t = Number(body.expires);
+                if (!Number.isInteger(t)) throw new ThrowableResponse(new FieldErrorResponse({expires: "Must be a number representing UNIX time."}));
+                if (t <= Date.now() / 1000) throw new ThrowableResponse(new FieldErrorResponse({expires: "Must be in the future."}));
+                return new Date(t * 1000);
+            },
+            scopes(body: any): Set<Scope> {
+                if (!("scopes" in body)) throw new ThrowableResponse(new FieldErrorResponse({scopes: "This field is required."}));
+                if (!Array.isArray(body.scopes)) throw new ThrowableResponse(new FieldErrorResponse({scopes: "Must be an array."}));
+                const set = new Set<Scope>();
+                for (const scope of body.scopes) {
+                    if (typeof scope !== "string") continue;
+                    if (!Object.values(Token.Scope).includes(scope as Token.Scope)) throw new ThrowableResponse(new FieldErrorResponse({scopes: `Unknown scope ${scope}`}));
+                    set.add(scope as Token.Scope);
+                }
+                return set;
+            },
+            note(body: any): string {
+                if (!("note" in body)) throw new ThrowableResponse(new FieldErrorResponse({note: "Please enter a note."}));
+                if (typeof body.note !== "string") throw new ThrowableResponse(new FieldErrorResponse({note: "Must be a string."}));
+                return body.note;
+            },
+            user(body: any): User.ID | null {
+                if (!("user" in body)) return null;
+                if (typeof body.user !== "string") throw new ThrowableResponse(new FieldErrorResponse({user: "Must be a string."}));
+                return new User.ID(body.user);
+            },
+            token(req: ApiRequest, repo: Token.Repository, id: string): Token {
+                if (req.auth === null)
+                    throw new ThrowableResponse(Authorisation.UNAUTHORISED);
+                if (!req.auth.scopes.has(Token.Scope.TOKENS_READ_ALL) && !req.auth.scopes.has(Token.Scope.TOKENS_READ_SELF))
+                    throw new ThrowableResponse(Authorisation.FORBIDDEN);
+
+                const token = repo.get(new Token.ID(id));
+                if (token === null || (!req.auth.scopes.has(Token.Scope.TOKENS_READ_ALL) && !token.user.equals(req.auth.user.id)))
+                    throw new ThrowableResponse(Token.Controller.notFound());
+                return token;
+            }
+        }
+
+        /**
+         * Validate that the authorisation context has access to all requested scopes, or else throw 403
+         */
+        private validateScopes(auth: Authorisation, scopes: Set<Token.Scope>) {
+            for (const scope of scopes)
+                if (!auth.scopes.has(scope)) throw new ThrowableResponse(new FieldErrorResponse({scopes: `You don't have permission to grant scope ${scope} in the current authorisation context.`}, {}, 403));
+        }
+
+        public static notFound() {
+            return new ErrorResponse(404, "The requested token could not be found.");
+        }
+
+        protected override list(req: ApiRequest): ApiResponse {
+            if (req.auth === null) return Authorisation.UNAUTHORISED;
+            if (!req.auth.scopes.has(Token.Scope.TOKENS_READ_ALL) && !req.auth.scopes.has(Token.Scope.TOKENS_READ_SELF)) return Authorisation.FORBIDDEN;
+            const limit = req.limit();
+            const tokens = req.auth.scopes.has(Token.Scope.TOKENS_READ_ALL)
+                ? (req.url.searchParams.has("user")
+                    ? this.library.repositories.tokens.listOfUser(new User.ID(req.url.searchParams.get("user")!), limit)
+                    : (req.url.searchParams.has("all")
+                        ? this.library.repositories.tokens.list(limit)
+                        : this.library.repositories.tokens.listOfUser(req.auth.user.id, limit)))
+                : this.library.repositories.tokens.listOfUser(req.auth.user.id, limit);
+
+            return new PageResponse(req, tokens.resources.map(t => t.json()), limit.page, limit.limit, tokens.total);
+        }
+
+        protected override create(req: ApiRequest): ApiResponse {
+            if (req.auth === null) return Authorisation.UNAUTHORISED;
+
+            const userId = req.auth.scopes.has(Token.Scope.TOKENS_WRITE_SELF)
+                ? req.auth.user.id
+                : (req.auth.scopes.has(Token.Scope.TOKENS_WRITE_ALL)
+                    ? this.extract.user(req.body) ?? req.auth.user.id
+                    : null);
+            if (userId === null) return Authorisation.FORBIDDEN;
+
+            const user = this.library.repositories.users.get(userId);
+            if (user === null) return new FieldErrorResponse({user: "A user with the provided ID does not exist."}, {}, 404);
+
+            this.validateBodyType(req.body);
+            const expires = this.extract.expires(req.body);
+            const scopes = this.extract.scopes(req.body);
+            const note = this.extract.note(req.body);
+            this.validateScopes(req.auth, scopes);
+            const token = new Token(Token.ID.random(), user.id, Token.Secret.random(), expires, scopes, note);
+            this.library.repositories.tokens.save(token);
+            return new JsonResponse(token.unsafeJson());
+        }
+
+        protected override deleteAll(req: ApiRequest): ApiResponse {
+            if (req.auth === null) return Authorisation.UNAUTHORISED;
+            if (req.auth.scopes.has(Token.Scope.TOKENS_WRITE_ALL)) this.library.repositories.tokens.deleteAll();
+            else if (req.auth.scopes.has(Token.Scope.TOKENS_WRITE_SELF)) this.library.repositories.tokens.deleteOfUser(req.auth.user.id);
+            else return Authorisation.FORBIDDEN;
+            return new EmptyReponse();
+        }
+
+        protected override get(req: ApiRequest, id: string): ApiResponse {
+            const token = this.extract.token(req, this.library.repositories.tokens, id);
+            return new JsonResponse(token.json());
+        }
+
+        protected override delete(req: ApiRequest, id: string): ApiResponse {
+            const token = this.extract.token(req, this.library.repositories.tokens, id);
+            this.library.repositories.tokens.delete(token.id);
+            return new EmptyReponse();
+        }
+
+        protected override put(req: ApiRequest, id: string): ApiResponse {
+            this.validateBodyType(req.body);
+            const token = this.extract.token(req, this.library.repositories.tokens, id);
+            token.note = this.extract.note(req.body);
+            this.library.repositories.tokens.save(token);
+            return new JsonResponse(token.json());
+        }
+
+        protected override patch(req: ApiRequest, id: string): ApiResponse {
+            this.validateBodyType(req.body);
+            const token = this.extract.token(req, this.library.repositories.tokens, id);
+            if ("note" in req.body) token.note = this.extract.note(req.body);
+            this.library.repositories.tokens.save(token);
+            return new JsonResponse(token.json());
+        }
+
+        private validateBodyType(body: JsonResponse.Object | JsonResponse.Array | Buffer) {
+            if (Buffer.isBuffer(body)) throw new ThrowableResponse(new ErrorResponse(415, "The request body has unsupported media type.", {
+                Accept: "application/json, application/x-www-form-urlencoded"
+            }));
+            if (Array.isArray(body)) throw new ThrowableResponse(new ErrorResponse(422, "The request body is an array; expected an object."));
+        }
+    }
+}
+
+export default Token;

--- a/src/resource/Token.ts
+++ b/src/resource/Token.ts
@@ -35,6 +35,10 @@ class Token extends ApiResource {
         this.#secret = secret;
     }
 
+    public get expired(): boolean {
+        return this.expires !== null && this.expires < new Date();
+    }
+
     public get secret(): Token.Secret {
         return this.#secret;
     }

--- a/src/resource/Track.ts
+++ b/src/resource/Track.ts
@@ -1,5 +1,5 @@
 import {parseFile as getMetadataFromFile} from "music-metadata";
-import ID_ from "../ID.js";
+import HashID from "../HashID.js";
 import File from "../File.js";
 import Artist from "./Artist.js";
 import Album from "./Album.js";
@@ -83,7 +83,7 @@ class Track extends ApiResource {
 }
 
 namespace Track {
-    export class ID extends ID_ {
+    export class ID extends HashID {
         public constructor(id: string) {
             super(id);
         }

--- a/src/resource/Track.ts
+++ b/src/resource/Track.ts
@@ -16,6 +16,7 @@ import ErrorResponse from "../response/ErrorResponse.js";
 import FileResponse from "../response/FileResponse.js";
 import Library from "../Library.js";
 import BufferResponse from "../response/BufferResponse.js";
+import Token from "./Token.js";
 
 class Track extends ApiResource {
     public constructor(
@@ -225,13 +226,15 @@ namespace Track {
         ];
 
         protected override list(req: ApiRequest): ApiResponse {
+            req.require(Token.Scope.LIBRARY_READ);
             const sort = req.url.searchParams.get("sort");
             const limit = req.limit();
             const tracks = this.library.repositories.tracks.list({limit: limit.limit, offset: limit.offset, sort});
             return new PageResponse(req, tracks.resources.map(t => t.json()), limit.page, limit.limit, tracks.total);
         }
 
-        protected override get(_req: ApiRequest, id: string): ApiResponse {
+        protected override get(req: ApiRequest, id: string): ApiResponse {
+            req.require(Token.Scope.LIBRARY_READ);
             const track = this.library.repositories.tracks.get(new Track.ID(id));
             if (track === null) return Track.Controller.notFound();
             return new JsonResponse(track.json());
@@ -252,7 +255,8 @@ namespace Track {
         }
 
         public override async handle(req: ApiRequest, urlParts: string[]): Promise<ApiResponse> {
-            if (req.method !== "GET") return Controller_.methodNotAllowed(req);
+            if (!["GET", "HEAD"].includes(req.method)) return Controller_.methodNotAllowed(req);
+            req.require(Token.Scope.LIBRARY_READ);
             const track = this.library.repositories.tracks.get(new Track.ID(urlParts[1]!));
             if (track === null) return Track.Controller.notFound();
             if (!await track.file.isReadable()) {
@@ -273,7 +277,8 @@ namespace Track {
         }
 
         public override async handle(req: ApiRequest, urlParts: string[]): Promise<ApiResponse> {
-            if (req.method !== "GET") return Controller_.methodNotAllowed(req);
+            if (!["GET", "HEAD"].includes(req.method)) return Controller_.methodNotAllowed(req);
+            req.require(Token.Scope.LIBRARY_READ);
             const track = this.library.repositories.tracks.get(new Track.ID(urlParts[1]!));
             if (track === null) return Track.Controller.notFound();
             if (!await track.file.isReadable()) {

--- a/src/resource/User.ts
+++ b/src/resource/User.ts
@@ -1,0 +1,242 @@
+import ApiResource from "../api/ApiResource.js";
+import JsonResponse from "../response/JsonResponse.js";
+import RandomID from "../RandomID.js";
+import Token from "./Token.js";
+import Password from "../Password.js";
+import Repository_ from "../Repository.js";
+import ResourceController from "../api/ResourceController.js";
+import ApiRequest from "../api/ApiRequest.js";
+import ApiResponse from "../response/ApiResponse.js";
+import PageResponse from "../response/PageResponse.js";
+import ErrorResponse from "../response/ErrorResponse.js";
+import EmptyReponse from "../response/EmptyReponse.js";
+import ThrowableResponse from "../response/ThrowableResponse.js";
+import FieldErrorResponse from "../response/FieldErrorResponse.js";
+
+class User extends ApiResource {
+    public constructor(
+        public override readonly id: User.ID,
+        public username: string,
+        public scopes: Set<Token.Scope>,
+        public password: Password,
+        public disabled: boolean
+    ) {
+        super();
+    }
+
+    public static row(row: Record<string, any>): User {
+        return new User(
+            new User.ID(row.id),
+            row.username,
+            new Set(JSON.parse(row.scopes)),
+            new Password(row.password),
+            row.disabled === 1
+        );
+    }
+
+    public override json(): JsonResponse.Object {
+        return {
+            id: this.id.id,
+            username: this.username,
+            scopes: Array.from(this.scopes.values()),
+            disabled: this.disabled
+        }
+    }
+}
+
+namespace User {
+    export class ID extends RandomID {
+        public static override random(): User.ID {
+            return new this(super.random().id);
+        }
+    }
+
+    export class Repository extends Repository_<User> {
+        private readonly statements = {
+            get: this.database.prepare<[string], Record<string, any>>("SELECT * FROM `users` WHERE `id` = ?"),
+            getByUsername: this.database.prepare<[string], Record<string, any>>("SELECT * FROM `users` WHERE `username` = ?"),
+            save: this.database.prepare<[string, string, string, string, 1 | 0], void>("REPLACE INTO `users` (`id`, `username`, `scopes`, `password`, `disabled`) VALUES (?, ?, ?, ?, ?)"),
+            deleteAll: this.database.prepare<[], void>("DELETE FROM `users`"),
+            list: this.database.prepare<[number, number], Record<string, any>>("SELECT * FROM `users` LIMIT ? OFFSET ?"),
+            count: this.database.prepare<[], { count: number }>("SELECT COUNT(*) as count FROM `users`"),
+            delete: this.database.prepare<[string], void>("DELETE FROM `users` WHERE `id` = ?"),
+        } as const;
+
+        public override get(id: User.ID) {
+            const row = this.statements.get.get(id.id);
+            if (row === undefined) return null;
+            return User.row(row);
+        }
+
+        public getByUsername(username: string) {
+            const row = this.statements.getByUsername.get(username);
+            if (row === undefined) return null;
+            return User.row(row);
+        }
+
+        public usernameAvailable(username: string) {
+            return this.getByUsername(username) === null;
+        }
+
+        public override list({limit, offset}: { limit: number, offset: number }) {
+            const rows = this.statements.list.all(limit, offset);
+            return {
+                resources: rows.map(User.row),
+                total: this.statements.count.get()!.count
+            }
+        }
+
+        public override save(resource: User) {
+            this.statements.save.run(resource.id.id, resource.username, JSON.stringify(Array.from(resource.scopes.values())), resource.password.hash, resource.disabled ? 1 : 0);
+        }
+
+        public deleteAll() {
+            this.statements.deleteAll.run();
+        }
+
+        public override delete(id: User.ID) {
+            this.statements.delete.run(id.id);
+        }
+    }
+
+    export class Controller extends ResourceController {
+        protected override readonly path = ["users"];
+        private readonly extract = {
+            username(body: any): string {
+                if (!("username" in body)) throw new ThrowableResponse(new FieldErrorResponse({username: "Please enter a username."}));
+                if (typeof body.username !== "string") throw new ThrowableResponse(new FieldErrorResponse({username: "Must be a string."}));
+                if (body.username.length < 3) throw new ThrowableResponse(new FieldErrorResponse({username: "Must be at least 3 characters long."}));
+                if (body.username.length > 24) throw new ThrowableResponse(new FieldErrorResponse({username: "Must not be longer than 24 characters."}));
+                if (!/^[a-zA-Z0-9-_.]+$/.test(body.username)) throw new ThrowableResponse(new FieldErrorResponse({username: "Must only contain alphanumeric characters, hyphens, underscores, and periods."}));
+                return body.username;
+            },
+            async password(body: any): Promise<Password> {
+                if (!("password" in body)) throw new ThrowableResponse(new FieldErrorResponse({password: "Please enter a password."}));
+                if (typeof body.password !== "string") throw new ThrowableResponse(new FieldErrorResponse({password: "Must be a string."}));
+                if (body.password.length < 3) throw new ThrowableResponse(new FieldErrorResponse({password: "Must be at least 3 characters long."}));
+                if (body.password.length > 24) throw new ThrowableResponse(new FieldErrorResponse({password: "Must not be longer than 24 characters."}));
+                return await Password.hash(body.password);
+            },
+            scopes(body: any): Set<Token.Scope> {
+                if (!("scopes" in body)) throw new ThrowableResponse(new FieldErrorResponse({scopes: "This field is required."}));
+                if (!Array.isArray(body.scopes)) throw new ThrowableResponse(new FieldErrorResponse({scopes: "Must be an array."}));
+                const set = new Set<Token.Scope>();
+                for (const scope of body.scopes) {
+                    if (typeof scope !== "string") continue;
+                    if (!Object.values(Token.Scope).includes(scope as Token.Scope)) throw new ThrowableResponse(new FieldErrorResponse({scopes: `Unknown scope ${scope}`}));
+                    set.add(scope as Token.Scope);
+                }
+                return set;
+            },
+            disabled(body: any): boolean {
+                if (!("disabled" in body)) return false;
+                if (
+                    body.disabled === true
+                    || body.disabled === "true"
+                    || body.disabled === 1
+                    || body.disabled === "1"
+                    || body.disabled === "on"
+                ) return true;
+                if (
+                    body.disabled === false
+                    || body.disabled === "false"
+                    || body.disabled === 0
+                    || body.disabled === "0"
+                ) return false;
+                throw new ThrowableResponse(new FieldErrorResponse({disabled: "Must be a boolean."}));
+            }
+        } as const;
+
+        public static notFound() {
+            return new ErrorResponse(404, "The requested user could not be found.");
+        }
+
+        protected override list(req: ApiRequest): ApiResponse {
+            req.require(Token.Scope.USERS_READ);
+            const limit = req.limit();
+            const users = this.library.repositories.users.list(limit);
+            return new PageResponse(req, users.resources.map(u => u.json()), limit.page, limit.limit, users.total);
+        }
+
+        protected override async create(req: ApiRequest): Promise<ApiResponse> {
+            req.require(Token.Scope.USERS_WRITE);
+            this.validateBodyType(req.body);
+            const username = this.extract.username(req.body);
+            const password = await this.extract.password(req.body);
+            const scopes = this.extract.scopes(req.body);
+            const disabled = this.extract.disabled(req.body);
+
+            if (!this.library.repositories.users.usernameAvailable(username))
+                return new ErrorResponse(409, `The username "${username}" is already taken.`);
+
+            const user = new User(User.ID.random(), username, scopes, password, disabled);
+            this.library.repositories.users.save(user);
+            return new JsonResponse(user.json(), 201);
+        }
+
+        protected override deleteAll(req: ApiRequest): ApiResponse {
+            req.require(Token.Scope.USERS_WRITE);
+            this.library.repositories.tokens.deleteAll();
+            this.library.repositories.users.deleteAll();
+            return new EmptyReponse();
+        }
+
+        protected override get(req: ApiRequest, id: string): ApiResponse {
+            req.require(Token.Scope.USERS_READ);
+            const user = this.library.repositories.users.get(new User.ID(id));
+            if (user === null) return User.Controller.notFound();
+            return new JsonResponse(user.json());
+        }
+
+        protected override delete(req: ApiRequest, id: string): ApiResponse {
+            req.require(Token.Scope.USERS_WRITE);
+            const user = this.library.repositories.users.get(new User.ID(id));
+            if (user === null) return User.Controller.notFound();
+            this.library.repositories.tokens.deleteOfUser(user.id);
+            this.library.repositories.users.delete(user.id);
+            return new EmptyReponse();
+        }
+
+        protected override async put(req: ApiRequest, id: string): Promise<ApiResponse> {
+            req.require(Token.Scope.USERS_WRITE);
+            const user = this.library.repositories.users.get(new User.ID(id));
+            if (user === null) return User.Controller.notFound();
+
+            this.validateBodyType(req.body);
+            const username = this.extract.username(req.body);
+            const password = await this.extract.password(req.body);
+            const scopes = this.extract.scopes(req.body);
+            const disabled = this.extract.disabled(req.body);
+
+            user.username = username;
+            user.password = password;
+            user.scopes = scopes;
+            user.disabled = disabled;
+            this.library.repositories.users.save(user);
+            return new JsonResponse(user.json());
+        }
+
+        protected override async patch(req: ApiRequest, id: string): Promise<ApiResponse> {
+            req.require(Token.Scope.USERS_WRITE);
+            const user = this.library.repositories.users.get(new User.ID(id));
+            if (user === null) return User.Controller.notFound();
+
+            this.validateBodyType(req.body);
+            if ("username" in req.body) user.username = this.extract.username(req.body);
+            if ("password" in req.body) user.password = await this.extract.password(req.body);
+            if ("scopes" in req.body) user.scopes = this.extract.scopes(req.body);
+            if ("disabled" in req.body) user.disabled = this.extract.disabled(req.body);
+            this.library.repositories.users.save(user);
+            return new JsonResponse(user.json());
+        }
+
+        private validateBodyType(body: JsonResponse.Object | JsonResponse.Array | Buffer) {
+            if (Buffer.isBuffer(body)) throw new ThrowableResponse(new ErrorResponse(415, "The request body has unsupported media type.", {
+                Accept: "application/json, application/x-www-form-urlencoded"
+            }));
+            if (Array.isArray(body)) throw new ThrowableResponse(new ErrorResponse(422, "The request body is an array; expected an object."));
+        }
+    }
+}
+
+export default User;

--- a/src/response/EmptyReponse.ts
+++ b/src/response/EmptyReponse.ts
@@ -1,0 +1,13 @@
+import ApiResponse from "./ApiResponse.js";
+import ApiRequest from "../api/ApiRequest.js";
+
+export default class EmptyReponse extends ApiResponse {
+    public constructor() {
+        super(204);
+    }
+
+    public override send(req: ApiRequest) {
+        req.res.statusCode = this.status;
+        req.res.end();
+    }
+}

--- a/src/response/ErrorResponse.ts
+++ b/src/response/ErrorResponse.ts
@@ -1,13 +1,15 @@
 import JsonResponse from "./JsonResponse.js";
 import ApiRequest from "../api/ApiRequest.js";
 
-export default class ErrorResponse extends JsonResponse {
-    public constructor(status: number, message: string, private readonly cause?: Error) {
-        super({error: {message}}, status);
+export default class ErrorResponse extends JsonResponse<{error: {message: string, fields: Record<string, string>}}> {
+    public constructor(status: number, message: string, protected readonly headers: Record<string, string> = {}, private readonly cause?: Error) {
+        super({error: {message, fields: {}}}, status);
     }
 
     public override send(req: ApiRequest): void {
         req.res.statusCode = this.status;
+        for (const [header, value] of Object.entries(this.headers))
+            req.res.setHeader(header, value);
         super.send(req);
 
         if (this.cause !== undefined) console.error(`Request error: ${req.req.socket.remoteAddress} ${req.method} ${req.url}\n`, this.cause);

--- a/src/response/FieldErrorResponse.ts
+++ b/src/response/FieldErrorResponse.ts
@@ -1,0 +1,11 @@
+import ErrorResponse from "./ErrorResponse.js";
+
+/**
+ * A 422 error indicating that one or more fields in the request body were invalid.
+ */
+export default class FieldErrorResponse extends ErrorResponse {
+    public constructor(fields: Record<string, string>, headers?: Record<string, string>, status = 422) {
+        super(status, "One or more fields in the request body were invalid.", headers);
+        this.data.error.fields = fields;
+    }
+}

--- a/src/response/FileResponse.ts
+++ b/src/response/FileResponse.ts
@@ -16,7 +16,7 @@ class FileResponse extends ApiResponse {
         catch (e) {
             if (e instanceof Error && "code" in e && e.code === "ENOENT")
                 return new ErrorResponse(404, "File not found").send(req);
-            return new ErrorResponse(500, "Internal server error", e as Error).send(req);
+            return new ErrorResponse(500, "Internal server error", {}, e as Error).send(req);
         }
 
         const rangeHeader = req.req.headers["range"];
@@ -27,7 +27,7 @@ class FileResponse extends ApiResponse {
         catch (e) {
             if (e instanceof SyntaxError)
                 return new ErrorResponse(400, e.message).send(req);
-            else return new ErrorResponse(500, "Internal server error", e as Error).send(req);
+            else return new ErrorResponse(500, "Internal server error", {}, e as Error).send(req);
         }
         if (ranges !== null && this.status === 200) {
             if (ranges.ranges.length === 0) return new ErrorResponse(400, "No ranges were specified").send(req);
@@ -38,7 +38,7 @@ class FileResponse extends ApiResponse {
             catch (e) {
                 if (e instanceof RangeError)
                     return new ErrorResponse(416, e.message).send(req);
-                else return new ErrorResponse(500, "Internal server error", e as Error).send(req);
+                else return new ErrorResponse(500, "Internal server error", {}, e as Error).send(req);
             }
            if (absoluteRanges.ranges.length === 1) {
                req.res.setHeader("Content-Type", this.file.type ?? "application/octet-stream");

--- a/src/response/JsonResponse.ts
+++ b/src/response/JsonResponse.ts
@@ -1,12 +1,12 @@
 import ApiResponse from "./ApiResponse.js";
 import ApiRequest from "../api/ApiRequest.js";
 
-class JsonResponse extends ApiResponse {
-    private readonly data: Readonly<JsonResponse.Object | JsonResponse.Array>;
+class JsonResponse<T extends JsonResponse.Object | JsonResponse.Array> extends ApiResponse {
+    protected readonly data: T;
 
-    public constructor(data: JsonResponse.Object | JsonResponse.Array, status: number = 200) {
+    public constructor(data: T, status: number = 200) {
         super(status);
-        this.data = Object.freeze(data);
+        this.data = data;
     }
 
     public override send(req: ApiRequest): void {

--- a/src/response/PageResponse.ts
+++ b/src/response/PageResponse.ts
@@ -1,7 +1,7 @@
 import JsonResponse from "./JsonResponse.js";
 import ApiRequest from "../api/ApiRequest.js";
 
-export default class PageResponse extends JsonResponse {
+export default class PageResponse extends JsonResponse<JsonResponse.Object> {
     public constructor(req: ApiRequest, resources: JsonResponse.Object[], page: number, limit: number, total: number = resources.length) {
         const href: URL = new URL(req.url);
         const previous: URL | null = page > 1 ? new URL(req.url) : null;

--- a/src/response/ThrowableResponse.ts
+++ b/src/response/ThrowableResponse.ts
@@ -1,0 +1,7 @@
+import ApiResponse from "./ApiResponse.js";
+
+export default class ThrowableResponse<T extends ApiResponse> extends Error {
+    public constructor(public readonly response: T) {
+        super();
+    }
+}


### PR DESCRIPTION
Auth is now required to access the library API (artists, albums, tracks).

Users have been added. Users can authenticate with the API using Basic auth (username and password) or Bearer auth (API Token).

Users have a set of Token Scopes (Permissions). Users can only create API Tokens with the same or fewer scopes. When Basic auth is used, the request Authorisation Context has the full permissions of the user. Using an API Token allows you to control the permissions.

Each API endpoint checks the Authorisation Context (or the lack thereof) and may return 401 (auth is missing or invalid) or 403 (auth is valid, but a required Token Scope is missing).

Left to do:
 - [x] Generate an admin user if there are no users
 - [x] Update the OpenAPI specification