### PR TITLE
Playlists

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -51,6 +51,10 @@ tags: [
       same version."
   },
   {
+    name: Playlists,
+    description: Playlists are ordered collections of tracks that users can create.
+  },
+  {
     name: Users,
     description: "Users are accounts secured by a password that can be used to access the Prelude server."
   },
@@ -1273,6 +1277,282 @@ paths:
         403:
           $ref: "#/components/responses/Forbidden"
 
+  /playlists:
+    get:
+      tags: [Playlists]
+      summary: List Playlists
+      security:
+        - basic: [playlists:read]
+        - bearer: [playlists:read]
+      operationId: getPlaylists
+      parameters: [
+        {
+          in: query,
+          description: Number of resources to return per page,
+          name: limit,
+          schema: {
+            type: integer,
+            default: 100,
+            minimum: 1
+          }
+        },
+        {
+          in: query,
+          description: Page number to return,
+          name: page,
+          schema: {
+            type: integer,
+            default: 1,
+            minimum: 1
+          }
+        },
+        {
+          in: query,
+          description: Show public playlists (except those owned by the authenticated user). Incompatible with `all`.,
+          name: public,
+          schema: {
+            type: string,
+            examples: [""]
+          }
+        },
+        {
+          in: query,
+          description: "Show all playlists, including private and unlisted playlists, of all users. Requires scope
+            `playlists:read:all`. Incompatible with `public`.",
+          name: all,
+          required: false,
+          schema: {
+            type: string,
+            examples: [""]
+          }
+        }
+      ]
+      responses:
+        200:
+          description: A page of playlists
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/Page"
+                  - type: object
+                    properties:
+                      resources:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/Playlist"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags: [Playlists]
+      summary: Create Playlist
+      security:
+        - basic: [playlists:write]
+        - bearer: [playlists:write]
+      operationId: createPlaylist
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaylistWrite"
+              required: [name, visibility, tracks]
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/PlaylistWrite"
+              required: [name, visibility, tracks]
+      responses:
+        201:
+          description: The created playlist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Playlist"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+        404:
+          description: Some of the requested tracks could not be found
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ErrorResponse"
+                  - type: object
+                    properties:
+                      error:
+                        type: object
+                        properties:
+                          fields:
+                            type: object
+                            properties:
+                              tracks:
+                                type: string
+                                description: Information about which track could not be found
+        422:
+          $ref: "#/components/responses/ValidationError"
+    delete:
+      tags: [Playlists]
+      summary: Delete All Playlists
+      security:
+        - basic: [playlists:write]
+        - bearer: [playlists:write]
+      operationId: deleteAllPlaylists
+      responses:
+        204:
+          description: All playlists deleted successfully
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+
+  /playlists/{id}:
+    get:
+      tags: [Playlists]
+      summary: Get Playlist
+      security:
+        - basic: [playlists:read]
+        - bearer: [playlists:read]
+      operationId: getPlaylist
+      parameters: [
+        {
+          in: path,
+          name: id,
+          required: true,
+          schema: {$ref: "#/components/schemas/Playlist/properties/id"}
+        }
+      ]
+      responses:
+        200:
+          description: The requested playlist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Playlist"
+        404:
+          description: Playlist not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    delete:
+      tags: [Playlists]
+      summary: Delete Playlist
+      security:
+        - basic: [playlists:write]
+        - bearer: [playlists:write]
+      operationId: deletePlaylist
+      parameters: [
+        {
+          in: path,
+          name: id,
+          required: true,
+          schema: {$ref: "#/components/schemas/Playlist/properties/id"}
+        }
+      ]
+      responses:
+        204:
+          description: Playlist deleted successfully
+        404:
+          description: Playlist not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+    put:
+      tags: [Playlists]
+      summary: Replace Playlist
+      security:
+        - basic: [playlists:write]
+        - bearer: [playlists:write]
+      operationId: replacePlaylist
+      parameters: [
+        {
+          in: path,
+          name: id,
+          required: true,
+          schema: {$ref: "#/components/schemas/Playlist/properties/id"}
+        }
+      ]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaylistWrite"
+              required: [name, visibility, tracks]
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/PlaylistWrite"
+              required: [name, visibility, tracks]
+      responses:
+        200:
+          description: The updated playlist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Playlist"
+        404:
+          description: Playlist not found, or some of the requested tracks could not be found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+        422:
+          $ref: "#/components/responses/ValidationError"
+    patch:
+      tags: [Playlists]
+      summary: Update Playlist
+      security:
+        - basic: [playlists:write]
+        - bearer: [playlists:write]
+      operationId: updatePlaylist
+      parameters: [
+        {
+          in: path,
+          name: id,
+          required: true,
+          schema: {$ref: "#/components/schemas/Playlist/properties/id"}
+        }
+      ]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PlaylistWrite"
+      responses:
+        200:
+          description: The updated playlist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Playlist"
+        404:
+          description: Playlist not found, or some of the requested tracks could not be found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        401:
+          $ref: "#/components/responses/Unauthorised"
+        403:
+          $ref: "#/components/responses/Forbidden"
+        422:
+          $ref: "#/components/responses/ValidationError"
+
 components:
   securitySchemes:
     basic:
@@ -1301,6 +1581,25 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
+    ValidationError:
+      description: Request body data validation. Specific errors for the fields that caused the error are in `fields`.
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/ErrorResponse"
+              - type: object
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      fields:
+                        type: object
+                        description: Errors specific to each request body field.
+                        additionalProperties:
+                          type: string
+                          description: Field-specific errors mapped to request body fields. If this object is not empty, these error messages should be shown instead of the one in `message`.
+                          examples: ["A user-friendly message regarding this field."]
   schemas:
     Artist:
       type: object
@@ -1425,6 +1724,35 @@ components:
               description: Whether the audio file is in a lossless/uncompressed format
               examples: [false]
 
+    Playlist:
+      type: object
+      properties:
+        id:
+          type: string
+          title: Playlist ID
+          examples: [d71c4bdc-e433-4413-a549-3a80be2962d3]
+        name:
+          type: string
+          description: A user-specified name for the playlist
+          maxLength: 128
+          examples: [My Playlist]
+        user:
+          $ref: "#/components/schemas/User/properties/id"
+        visibility:
+          type: string
+          description: |-
+            Specifies the visibility of the playlist.
+              - `private`: Only the creator and users with the `playlists:read:all` scope can see the playlist. It is not accessible or visible to others.
+              - `unlisted`: The playlist can be viewed by anyone who has the playlist ID. It will appear in lists only for the creator and users with the `playlists:read:all` scope.
+              - `public`: The playlist is accessible and visible to anyone with the `playlists:read` scope.
+          examples: [private]
+        tracks:
+          type: array
+          items:
+            $ref: "#/components/schemas/Track/properties/id"
+          description: A list of tracks in the playlist. The same track can appear multiple times in the list. Some tracks may no longer exist in the library.
+          examples: [[lJzqGqUGjPdAI+bEOrtHeLstgTU,FPcidn2LCPPQ1FYMAJH7-WN3wJE]]
+
     User:
       type: object
       properties:
@@ -1473,6 +1801,7 @@ components:
         note:
           type: string
           description: A user-specified note for the token (e.g. description of what this token is for).
+          maxLength: 128
 
     Scope:
       description: Controls access to API resources
@@ -1524,9 +1853,6 @@ components:
               examples: [A user-friendly error message.]
             fields:
               type: object
-              additionalProperties:
-                type: string
-                examples: [Field-specific errors mapped to request body fields. If this object is not empty, these error messages should be shown instead of the one in `message`.]
 
     BooleanLike:
       oneOf:
@@ -1551,6 +1877,16 @@ components:
           $ref: "#/components/schemas/User/properties/scopes"
         disabled:
           $ref: "#/components/schemas/BooleanLike"
+
+    PlaylistWrite:
+      type: object
+      properties:
+        name:
+          $ref: "#/components/schemas/Playlist/properties/name"
+        visibility:
+          $ref: "#/components/schemas/Playlist/properties/visibility"
+        tracks:
+          $ref: "#/components/schemas/Playlist/properties/tracks"
 
   requestBodies:
     User:

--- a/src/Library.ts
+++ b/src/Library.ts
@@ -7,6 +7,7 @@ import Track from "./resource/Track.js";
 import Config from "./Config.js";
 import User from "./resource/User.js";
 import Token from "./resource/Token.js";
+import Playlist from "./resource/Playlist.js";
 
 export default class Library {
     /**
@@ -37,7 +38,7 @@ export default class Library {
         "wma"                  // WMA
     ];
 
-    public readonly repositories: { artists: Artist.Repository, albums: Album.Repository, tracks: Track.Repository, users: User.Repository, tokens: Token.Repository };
+    public readonly repositories: { artists: Artist.Repository, albums: Album.Repository, tracks: Track.Repository, users: User.Repository, tokens: Token.Repository, playlists: Playlist.Repository };
 
     public constructor(private readonly db: Database, public readonly config: Config) {
         this.db = new Database(this.config.db);
@@ -47,6 +48,7 @@ export default class Library {
             tracks: new Track.Repository(this.db),
             users: new User.Repository(this.db),
             tokens: new Token.Repository(this.db),
+            playlists: new Playlist.Repository(this.db),
         }
     }
 

--- a/src/db/init.sql
+++ b/src/db/init.sql
@@ -60,3 +60,15 @@ CREATE TABLE IF NOT EXISTS `tokens`
 );
 
 CREATE INDEX IF NOT EXISTS `tokens_user` ON `tokens` (`user`);
+
+CREATE TABLE IF NOT EXISTS `playlists`
+(
+    `id`         CHAR(36) PRIMARY KEY NOT NULL COLLATE nocase,
+    `name`       VARCHAR(128)         NOT NULL COLLATE nocase,
+    `user`       CHAR(36)             NOT NULL COLLATE nocase,
+    `visibility` VARCHAR(8)           NOT NULL COLLATE nocase,
+    `tracks`     TEXT                 NOT NULL COLLATE binary,
+    FOREIGN KEY (`user`) REFERENCES `users` (`id`)
+);
+
+CREATE INDEX IF NOT EXISTS `playlist_user` ON `playlists` (`user`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import Track from "./resource/Track.js";
 import User from "./resource/User.js";
 import Token from "./resource/Token.js";
 import Password from "./Password.js";
+import Playlist from "./resource/Playlist.js";
 
 const configArgIndex = process.argv.findIndex(arg => arg === "--config" || arg === "-c");
 const customConfig = configArgIndex >= 0 && process.argv.length > configArgIndex + 1;
@@ -46,6 +47,7 @@ const server = await new Server(config, packageJson, [
     new Track.Controller(library),
     new User.Controller(library),
     new Token.Controller(library),
+    new Playlist.Controller(library),
 ], library).listen();
 console.log(`Server listening on http://0.0.0.0:${config.port}`);
 

--- a/src/resource/Playlist.ts
+++ b/src/resource/Playlist.ts
@@ -153,7 +153,7 @@ namespace Playlist {
                 return body.name;
             },
             user(auth: Authorisation, users: User.Repository, body: any): User.ID {
-                if (!auth.scopes.has(Token.Scope.PLAYLISTS_WRITE_ALL) || !("user" in body)) return auth.user.id;
+                if (!auth.has(Token.Scope.PLAYLISTS_WRITE_ALL) || !("user" in body)) return auth.user.id;
                 if (typeof body.user !== "string") throw new ThrowableResponse(new FieldErrorResponse({user: "Must be a string."}));
                 const user = users.get(new User.ID(body.user));
                 if (user === null) throw new ThrowableResponse(new FieldErrorResponse({user: "A user with the provided ID does not exist."}, {}, 404));
@@ -184,7 +184,7 @@ namespace Playlist {
             req.require(Token.Scope.PLAYLISTS_READ);
             const limit = req.limit();
             let playlists: {resources: Playlist[], total: number};
-            if (req.url.searchParams.has("all") && !req.auth!.scopes.has(Token.Scope.PLAYLISTS_READ_ALL))
+            if (req.url.searchParams.has("all") && !req.auth!.has(Token.Scope.PLAYLISTS_READ_ALL))
                 playlists = this.library.repositories.playlists.list(limit);
             else if (req.url.searchParams.has("public"))
                 playlists = this.library.repositories.playlists.listPublicExceptUser(req.auth!.user.id, limit);
@@ -208,9 +208,9 @@ namespace Playlist {
 
         public override deleteAll(req: ApiRequest): ApiResponse {
             if (req.auth === null) return Authorisation.UNAUTHORISED;
-            if (req.auth.scopes.has(Token.Scope.PLAYLISTS_WRITE_ALL))
+            if (req.auth.has(Token.Scope.PLAYLISTS_WRITE_ALL))
                 this.library.repositories.playlists.deleteAll();
-            else if (req.auth.scopes.has(Token.Scope.PLAYLISTS_WRITE))
+            else if (req.auth.has(Token.Scope.PLAYLISTS_WRITE))
                 this.library.repositories.playlists.deleteOfUser(req.auth.user.id);
             else return Authorisation.FORBIDDEN;
             return new EmptyReponse();
@@ -219,14 +219,14 @@ namespace Playlist {
         protected override get(req: ApiRequest, id: string): ApiResponse {
             req.require(Token.Scope.PLAYLISTS_READ);
             const playlist = this.library.repositories.playlists.get(new Playlist.ID(id));
-            if (playlist === null || (playlist.visibility === Playlist.Visibility.PRIVATE && !req.auth!.scopes.has(Token.Scope.PLAYLISTS_READ_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
+            if (playlist === null || (playlist.visibility === Playlist.Visibility.PRIVATE && !req.auth!.has(Token.Scope.PLAYLISTS_READ_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
             return new JsonResponse(playlist.json());
         }
 
         protected override delete(req: ApiRequest, id: string): ApiResponse {
             req.require(Token.Scope.PLAYLISTS_WRITE);
             const playlist = this.library.repositories.playlists.get(new Playlist.ID(id));
-            if (playlist === null || (!req.auth!.scopes.has(Token.Scope.PLAYLISTS_WRITE_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
+            if (playlist === null || (!req.auth!.has(Token.Scope.PLAYLISTS_WRITE_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
             this.library.repositories.playlists.delete(playlist.id);
             return new EmptyReponse();
         }
@@ -235,7 +235,7 @@ namespace Playlist {
             req.require(Token.Scope.PLAYLISTS_WRITE);
             this.validateBodyType(req.body);
             const playlist = this.library.repositories.playlists.get(new Playlist.ID(id));
-            if (playlist === null || (!req.auth!.scopes.has(Token.Scope.PLAYLISTS_WRITE_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
+            if (playlist === null || (!req.auth!.has(Token.Scope.PLAYLISTS_WRITE_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
             const name = this.extract.name(req.body);
             const visibility = this.extract.visibility(req.body);
             const tracks = this.extract.tracks(this.library.repositories.tracks, req.body);
@@ -250,7 +250,7 @@ namespace Playlist {
             req.require(Token.Scope.PLAYLISTS_WRITE);
             this.validateBodyType(req.body);
             const playlist = this.library.repositories.playlists.get(new Playlist.ID(id));
-            if (playlist === null || (!req.auth!.scopes.has(Token.Scope.PLAYLISTS_WRITE_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
+            if (playlist === null || (!req.auth!.has(Token.Scope.PLAYLISTS_WRITE_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
             if ("name" in req.body) playlist.name = this.extract.name(req.body);
             if ("visibility" in req.body) playlist.visibility = this.extract.visibility(req.body);
             if ("tracks" in req.body) playlist.tracks = this.extract.tracks(this.library.repositories.tracks, req.body);

--- a/src/resource/Playlist.ts
+++ b/src/resource/Playlist.ts
@@ -1,0 +1,270 @@
+import ApiResource from "../api/ApiResource.js";
+import RandomID from "../RandomID.js";
+import User from "./User.js";
+import Track from "./Track.js";
+import JsonResponse from "../response/JsonResponse.js";
+import Repository_ from "../Repository.js";
+import ResourceController from "../api/ResourceController.js";
+import Token from "./Token.js";
+import ApiRequest from "../api/ApiRequest.js";
+import ApiResponse from "../response/ApiResponse.js";
+import PageResponse from "../response/PageResponse.js";
+import ErrorResponse from "../response/ErrorResponse.js";
+import Authorisation from "../Authorisation.js";
+import EmptyReponse from "../response/EmptyReponse.js";
+import ThrowableResponse from "../response/ThrowableResponse.js";
+import FieldErrorResponse from "../response/FieldErrorResponse.js";
+
+class Playlist extends ApiResource {
+    public constructor(
+        public override readonly id: Playlist.ID,
+        public name: string,
+        public readonly user: User.ID,
+        public visibility: Playlist.Visibility,
+        public tracks: Track.ID[]
+    ) {
+        super();
+    }
+
+    public static row(row: Record<string, any>): Playlist {
+        return new Playlist(
+            new Playlist.ID(row.id),
+            row.name,
+            new User.ID(row.user),
+            row.visibility,
+            JSON.parse(row.tracks).map((t: string) => new Track.ID(t))
+        );
+    }
+
+    public override json(): JsonResponse.Object {
+        return {
+            id: this.id.id,
+            name: this.name,
+            user: this.user.id,
+            visibility: this.visibility,
+            tracks: this.tracks.map(t => t.id)
+        }
+    }
+}
+
+namespace Playlist {
+    export class ID extends RandomID {
+        public static override random(): Playlist.ID {
+            return new this(super.random().id);
+        }
+    }
+
+    export enum Visibility {
+        /**
+         * The playlist is only visible to its owner.
+         * The owner can see it in their list and access it using its ID.
+         */
+        PRIVATE = "private",
+
+        /**
+         * The playlist is visible to the owner in their list and can be accessed by anyone with the playlist ID.
+         * It is not included in any public lists or searchable by other users.
+         */
+        UNLISTED = "unlisted",
+
+        /**
+         * The playlist is visible to everyone.
+         * It is included in public lists and can be searched and accessed by all users.
+         */
+        PUBLIC = "public"
+    }
+
+    export class Repository extends Repository_<Playlist> {
+        private readonly statements = {
+            get: this.database.prepare<[string], Record<string, any>>("SELECT * FROM `playlists` WHERE `id` = ?"),
+            list: this.database.prepare<[number, number], Record<string, any>>("SELECT * FROM `playlists` LIMIT ? OFFSET ?"),
+            listByUser: this.database.prepare<[string, number, number], Record<string, any>>("SELECT * FROM `playlists` WHERE `user` = ? LIMIT ? OFFSET ?"),
+            listPublicExceptUser: this.database.prepare<[string, number, number], Record<string, any>>("SELECT * FROM `playlists` WHERE `visibility` = 'public' AND `user` != ? LIMIT ? OFFSET ?"),
+            count: this.database.prepare<[], { count: number }>("SELECT COUNT(*) as count FROM `playlists`"),
+            save: this.database.prepare<[string, string, string, string, string], void>("REPLACE INTO `playlists` (`id`, `name`, `user`, `visibility`, `tracks`) VALUES (?, ?, ?, ?, ?)"),
+            delete: this.database.prepare<[string], void>("DELETE FROM `playlists` WHERE `id` = ?"),
+            deleteAll: this.database.prepare<[], void>("DELETE FROM `playlists`"),
+            deleteOfUser: this.database.prepare<[string], void>("DELETE FROM `playlists` WHERE `user` = ?"),
+        } as const;
+
+        public override get(id: Playlist.ID) {
+            const row = this.statements.get.get(id.id);
+            if (row === undefined) return null;
+            return Playlist.row(row);
+        }
+
+        public override list({limit, offset}: { limit: number, offset: number }) {
+            const rows = this.statements.list.all(limit, offset);
+            return {
+                resources: rows.map(Playlist.row),
+                total: this.statements.count.get()!.count
+            };
+        }
+
+        public listByUser(user: User.ID, {limit, offset}: { limit: number, offset: number }) {
+            const rows = this.statements.listByUser.all(user.id, limit, offset);
+            return {
+                resources: rows.map(Playlist.row),
+                total: this.statements.count.get()!.count
+            };
+        }
+
+        public listPublicExceptUser(user: User.ID, {limit, offset}: { limit: number, offset: number }) {
+            const rows = this.statements.listPublicExceptUser.all(user.id, limit, offset);
+            return {
+                resources: rows.map(Playlist.row),
+                total: this.statements.count.get()!.count
+            };
+        }
+
+        public override save(resource: Playlist) {
+            this.statements.save.run(
+                resource.id.id,
+                resource.name,
+                resource.user.id,
+                resource.visibility,
+                JSON.stringify(resource.tracks.map(t => t.id))
+            );
+        }
+
+        public override delete(id: Playlist.ID) {
+            this.statements.delete.run(id.id);
+        }
+
+        public deleteAll() {
+            this.statements.deleteAll.run();
+        }
+
+        public deleteOfUser(user: User.ID) {
+            this.statements.deleteOfUser.run(user.id);
+        }
+    }
+
+    export class Controller extends ResourceController {
+        public override readonly path = ["playlists"];
+
+        private static readonly notFound = new ErrorResponse(404, "The requested playlist could not be found.");
+
+        private readonly extract = {
+            name(body: any): string {
+                if (!("name" in body)) throw new ThrowableResponse(new FieldErrorResponse({expires: "Please enter a name for this playlist."}));
+                if (typeof body.name !== "string") throw new ThrowableResponse(new FieldErrorResponse({name: "Must be a string."}));
+                if (body.name.length > 128) throw new ThrowableResponse(new FieldErrorResponse({note: "Must be 128 characters or less."}));
+                return body.name;
+            },
+            user(auth: Authorisation, users: User.Repository, body: any): User.ID {
+                if (!auth.scopes.has(Token.Scope.PLAYLISTS_WRITE_ALL) || !("user" in body)) return auth.user.id;
+                if (typeof body.user !== "string") throw new ThrowableResponse(new FieldErrorResponse({user: "Must be a string."}));
+                const user = users.get(new User.ID(body.user));
+                if (user === null) throw new ThrowableResponse(new FieldErrorResponse({user: "A user with the provided ID does not exist."}, {}, 404));
+                return user.id;
+            },
+            visibility(body: any): Playlist.Visibility {
+                if (!("visibility" in body)) throw new ThrowableResponse(new FieldErrorResponse({expires: "Please select playlist visibility."}));
+                if (typeof body.visibility !== "string") throw new ThrowableResponse(new FieldErrorResponse({visibility: "Must be a string."}));
+                if (!Object.values(Playlist.Visibility).includes(body.visibility as Playlist.Visibility)) throw new ThrowableResponse(new FieldErrorResponse({visibility: "Invalid visibility setting."}));
+                return body.visibility as Playlist.Visibility;
+            },
+            tracks(tracks: Track.Repository, body: any): Track.ID[] {
+                if (!("tracks" in body)) throw new ThrowableResponse(new FieldErrorResponse({tracks: "Please select the tracks for this playlist."}));
+                if (!Array.isArray(body.tracks)) throw new ThrowableResponse(new FieldErrorResponse({tracks: "Must be an array."}));
+                const ids: Track.ID[] = [];
+                for (const track of body.tracks) {
+                    if (typeof track !== "string") continue;
+                    const id = new Track.ID(track);
+                    if (tracks.get(id) === null) throw new ThrowableResponse(new FieldErrorResponse({tracks: `Track ${id} does not exist.`}, {}, 404));
+                    ids.push(id);
+                }
+                if (ids.length === 0) throw new ThrowableResponse(new FieldErrorResponse({tracks: "The playlist must have at least one track."}));
+                return ids;
+            }
+        } as const;
+
+        public override list(req: ApiRequest): ApiResponse {
+            req.require(Token.Scope.PLAYLISTS_READ);
+            const limit = req.limit();
+            let playlists: {resources: Playlist[], total: number};
+            if (req.url.searchParams.has("all") && !req.auth!.scopes.has(Token.Scope.PLAYLISTS_READ_ALL))
+                playlists = this.library.repositories.playlists.list(limit);
+            else if (req.url.searchParams.has("public"))
+                playlists = this.library.repositories.playlists.listPublicExceptUser(req.auth!.user.id, limit);
+            else
+                playlists = this.library.repositories.playlists.listByUser(req.auth!.user.id, limit);
+            return new PageResponse(req, playlists.resources.map(p => p.json()), limit.page, limit.limit, playlists.total);
+        }
+
+        public override create(req: ApiRequest): ApiResponse | Promise<ApiResponse> {
+            req.require(Token.Scope.PLAYLISTS_WRITE);
+            this.validateBodyType(req.body);
+            const name = this.extract.name(req.body);
+            const user = this.extract.user(req.auth!, this.library.repositories.users, req.body);
+            const visibility = this.extract.visibility(req.body);
+            const tracks = this.extract.tracks(this.library.repositories.tracks, req.body);
+
+            const playlist = new Playlist(Playlist.ID.random(), name, user, visibility, tracks);
+            this.library.repositories.playlists.save(playlist);
+            return new JsonResponse(playlist.json(), 201);
+        }
+
+        public override deleteAll(req: ApiRequest): ApiResponse {
+            if (req.auth === null) return Authorisation.UNAUTHORISED;
+            if (req.auth.scopes.has(Token.Scope.PLAYLISTS_WRITE_ALL))
+                this.library.repositories.playlists.deleteAll();
+            else if (req.auth.scopes.has(Token.Scope.PLAYLISTS_WRITE))
+                this.library.repositories.playlists.deleteOfUser(req.auth.user.id);
+            else return Authorisation.FORBIDDEN;
+            return new EmptyReponse();
+        }
+
+        protected override get(req: ApiRequest, id: string): ApiResponse {
+            req.require(Token.Scope.PLAYLISTS_READ);
+            const playlist = this.library.repositories.playlists.get(new Playlist.ID(id));
+            if (playlist === null || (playlist.visibility === Playlist.Visibility.PRIVATE && !req.auth!.scopes.has(Token.Scope.PLAYLISTS_READ_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
+            return new JsonResponse(playlist.json());
+        }
+
+        protected override delete(req: ApiRequest, id: string): ApiResponse {
+            req.require(Token.Scope.PLAYLISTS_WRITE);
+            const playlist = this.library.repositories.playlists.get(new Playlist.ID(id));
+            if (playlist === null || (!req.auth!.scopes.has(Token.Scope.PLAYLISTS_WRITE_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
+            this.library.repositories.playlists.delete(playlist.id);
+            return new EmptyReponse();
+        }
+
+        protected override put(req: ApiRequest, id: string): ApiResponse {
+            req.require(Token.Scope.PLAYLISTS_WRITE);
+            this.validateBodyType(req.body);
+            const playlist = this.library.repositories.playlists.get(new Playlist.ID(id));
+            if (playlist === null || (!req.auth!.scopes.has(Token.Scope.PLAYLISTS_WRITE_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
+            const name = this.extract.name(req.body);
+            const visibility = this.extract.visibility(req.body);
+            const tracks = this.extract.tracks(this.library.repositories.tracks, req.body);
+            playlist.name = name;
+            playlist.visibility = visibility;
+            playlist.tracks = tracks;
+            this.library.repositories.playlists.save(playlist);
+            return new JsonResponse(playlist.json());
+        }
+
+        protected override patch(req: ApiRequest, id: string): ApiResponse {
+            req.require(Token.Scope.PLAYLISTS_WRITE);
+            this.validateBodyType(req.body);
+            const playlist = this.library.repositories.playlists.get(new Playlist.ID(id));
+            if (playlist === null || (!req.auth!.scopes.has(Token.Scope.PLAYLISTS_WRITE_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
+            if ("name" in req.body) playlist.name = this.extract.name(req.body);
+            if ("visibility" in req.body) playlist.visibility = this.extract.visibility(req.body);
+            if ("tracks" in req.body) playlist.tracks = this.extract.tracks(this.library.repositories.tracks, req.body);
+            this.library.repositories.playlists.save(playlist);
+            return new JsonResponse(playlist.json());
+        }
+
+        private validateBodyType(body: JsonResponse.Object | JsonResponse.Array | Buffer) {
+            if (Buffer.isBuffer(body)) throw new ThrowableResponse(new ErrorResponse(415, "The request body has unsupported media type.", {
+                Accept: "application/json, application/x-www-form-urlencoded"
+            }));
+            if (Array.isArray(body)) throw new ThrowableResponse(new ErrorResponse(422, "The request body is an array; expected an object."));
+        }
+    }
+}
+
+export default Playlist;

--- a/src/resource/Playlist.ts
+++ b/src/resource/Playlist.ts
@@ -226,7 +226,8 @@ namespace Playlist {
         protected override delete(req: ApiRequest, id: string): ApiResponse {
             req.require(Token.Scope.PLAYLISTS_WRITE);
             const playlist = this.library.repositories.playlists.get(new Playlist.ID(id));
-            if (playlist === null || (!req.auth!.has(Token.Scope.PLAYLISTS_WRITE_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
+            if (playlist === null || (!playlist.user.equals(req.auth!.user.id) && playlist.visibility === Playlist.Visibility.PRIVATE)) return Playlist.Controller.notFound;
+            if (!playlist.user.equals(req.auth!.user.id)) req.require(Token.Scope.PLAYLISTS_WRITE_ALL);
             this.library.repositories.playlists.delete(playlist.id);
             return new EmptyReponse();
         }
@@ -235,7 +236,8 @@ namespace Playlist {
             req.require(Token.Scope.PLAYLISTS_WRITE);
             this.validateBodyType(req.body);
             const playlist = this.library.repositories.playlists.get(new Playlist.ID(id));
-            if (playlist === null || (!req.auth!.has(Token.Scope.PLAYLISTS_WRITE_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
+            if (playlist === null || (!playlist.user.equals(req.auth!.user.id) && playlist.visibility === Playlist.Visibility.PRIVATE)) return Playlist.Controller.notFound;
+            if (!playlist.user.equals(req.auth!.user.id)) req.require(Token.Scope.PLAYLISTS_WRITE_ALL);
             const name = this.extract.name(req.body);
             const visibility = this.extract.visibility(req.body);
             const tracks = this.extract.tracks(this.library.repositories.tracks, req.body);
@@ -250,7 +252,8 @@ namespace Playlist {
             req.require(Token.Scope.PLAYLISTS_WRITE);
             this.validateBodyType(req.body);
             const playlist = this.library.repositories.playlists.get(new Playlist.ID(id));
-            if (playlist === null || (!req.auth!.has(Token.Scope.PLAYLISTS_WRITE_ALL) && !playlist.user.equals(req.auth!.user.id))) return Playlist.Controller.notFound;
+            if (playlist === null || (!playlist.user.equals(req.auth!.user.id) && playlist.visibility === Playlist.Visibility.PRIVATE)) return Playlist.Controller.notFound;
+            if (!playlist.user.equals(req.auth!.user.id)) req.require(Token.Scope.PLAYLISTS_WRITE_ALL);
             if ("name" in req.body) playlist.name = this.extract.name(req.body);
             if ("visibility" in req.body) playlist.visibility = this.extract.visibility(req.body);
             if ("tracks" in req.body) playlist.tracks = this.extract.tracks(this.library.repositories.tracks, req.body);

--- a/src/resource/Playlist.ts
+++ b/src/resource/Playlist.ts
@@ -147,7 +147,7 @@ namespace Playlist {
 
         private readonly extract = {
             name(body: any): string {
-                if (!("name" in body)) throw new ThrowableResponse(new FieldErrorResponse({expires: "Please enter a name for this playlist."}));
+                if (!("name" in body)) throw new ThrowableResponse(new FieldErrorResponse({name: "Please enter a name for this playlist."}));
                 if (typeof body.name !== "string") throw new ThrowableResponse(new FieldErrorResponse({name: "Must be a string."}));
                 if (body.name.length > 128) throw new ThrowableResponse(new FieldErrorResponse({note: "Must be 128 characters or less."}));
                 return body.name;
@@ -160,7 +160,7 @@ namespace Playlist {
                 return user.id;
             },
             visibility(body: any): Playlist.Visibility {
-                if (!("visibility" in body)) throw new ThrowableResponse(new FieldErrorResponse({expires: "Please select playlist visibility."}));
+                if (!("visibility" in body)) throw new ThrowableResponse(new FieldErrorResponse({visibility: "Please select playlist visibility."}));
                 if (typeof body.visibility !== "string") throw new ThrowableResponse(new FieldErrorResponse({visibility: "Must be a string."}));
                 if (!Object.values(Playlist.Visibility).includes(body.visibility as Playlist.Visibility)) throw new ThrowableResponse(new FieldErrorResponse({visibility: "Invalid visibility setting."}));
                 return body.visibility as Playlist.Visibility;

--- a/src/resource/Token.ts
+++ b/src/resource/Token.ts
@@ -162,7 +162,35 @@ namespace Token {
          *
          * Recommended for: admin
          */
-        USERS_WRITE = "users:write"
+        USERS_WRITE = "users:write",
+
+        /**
+         * Read-only access to {@link Playlist}s (excluding private playlists of other users)
+         *
+         * Recommended for: everyone
+         */
+        PLAYLISTS_READ = "playlists:read",
+
+        /**
+         * Write/modify access to your own {@link Playlist}s
+         *
+         * Recommended for: everyone
+         */
+        PLAYLISTS_WRITE = "playlists:write",
+
+        /**
+         * Read-only access to everyone's {@link Playlist}s
+         *
+         * Recommended for: admin
+         */
+        PLAYLISTS_READ_ALL = "playlists:read:all",
+
+        /**
+         * Write/modify access to everyone's {@link Playlist}s
+         *
+         * Recommended for: admin
+         */
+        PLAYLISTS_WRITE_ALL = "playlists:write:all",
     }
 
     export class Repository extends Repository_<Token> {


### PR DESCRIPTION
Ordered list of tracks. Same track can be present multiple times. Some tracks in the playlist may not exist in the library and 404 when trying to `GET` them. Clients should ignore these tracks or show something like a "Not available" message. Since track IDs are hashes and not random, the missing tracks can become available if added to the library again.

To change the order of the tracks and to add/remove tracks, clients should send a `PATCH` request with the new list of tracks.

Playlists have several visibilities, `public`, `unlisted` and `private`:

> Specifies the visibility of the playlist. 
>  - `private`: Only the creator and users with the `playlists:read:all` scope can see the playlist. It is not accessible or visible to others. 
>  - `unlisted`: The playlist can be viewed by anyone who has the playlist ID. It will appear in lists only for the creator and users with the `playlists:read:all` scope. 
>  - `public`: The playlist is accessible and visible to anyone with the `playlists:read` scope.
>
> — [**Source**](https://github.com/prelude-music/server/blob/40311447fbb7e27e4aadec9c5d440f01951785b3/openapi.yaml#L1741-L1748)